### PR TITLE
Customize name of addon to add streaming provider as suffix

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -145,6 +145,10 @@ async def get_manifest(
         cat for cat in manifest["catalogs"] if cat["id"] in user_data.selected_catalogs
     ]
     manifest["catalogs"] = filtered_catalogs
+
+    # Customize the name of the addon if a streaming provider is configured
+    if user_data.streaming_provider is not None:
+        manifest["name"] = f"{manifest['name']} {user_data.streaming_provider.service}"
     return manifest
 
 


### PR DESCRIPTION
Similar to https://github.com/TheBeastLT/torrentio-scraper/commit/96879c13cd31a5c4dbf61cffd2fb0098d1ecdc9c in torrentio, customize the name of the addon to add a suffix of the streaming provider if any is configured, this helps in distinguishing whether its using direct torrent vs a streaming provider if both are installed at the same time.

Tested with direct torrent and a fake RD setup and observed the manifest.json output

Direct streaming : 
```
"version":"3.5.5","name":"Media Fusion"
```

RD configured :
```
"version":"3.5.5","name":"Media Fusion realdebrid"
```