### PR TITLE
Integrate new streaming provider Torbox

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -23,6 +23,7 @@ from streaming_providers.realdebrid.api import router as realdebrid_router
 from streaming_providers.realdebrid.utils import get_direct_link_from_realdebrid
 from streaming_providers.seedr.api import router as seedr_router
 from streaming_providers.seedr.utils import get_direct_link_from_seedr
+from streaming_providers.torbox.utils import get_direct_link_from_torbox
 from utils import crypto, torrent, poster, validation_helper, const
 
 logging.basicConfig(
@@ -409,6 +410,10 @@ async def streaming_provider_endpoint(
         elif user_data.streaming_provider.service == "pikpak":
             video_url = await get_direct_link_from_pikpak(
                 info_hash, magnet_link, user_data, stream, filename, 1, 0
+            )
+        elif user_data.streaming_provider.service == "torbox":
+            video_url = get_direct_link_from_torbox(
+                info_hash, magnet_link, user_data, filename, 1, 0
             )
         else:
             video_url = get_direct_link_from_debridlink(

--- a/db/schemas.py
+++ b/db/schemas.py
@@ -62,7 +62,7 @@ class Streams(BaseModel):
 
 class StreamingProvider(BaseModel):
     service: Literal[
-        "realdebrid", "seedr", "debridlink", "alldebrid", "offcloud", "pikpak"
+        "realdebrid", "seedr", "debridlink", "alldebrid", "offcloud", "pikpak", "torbox"
     ]
     token: str | None = None
     username: str | None = None

--- a/resources/html/configure.html
+++ b/resources/html/configure.html
@@ -30,6 +30,7 @@
                         <option value="pikpak" {% if user_data.streaming_provider.service=='pikpak' %}selected{% endif %}>PikPak (Free Quota)</option>
                         <option value="seedr" {% if user_data.streaming_provider.service=='seedr' %}selected{% endif %}>Seedr.cc (Free Quota)</option>
                         <option value="offcloud" {% if user_data.streaming_provider.service=='offcloud' %}selected{% endif %}>OffCloud (Free Quota)</option>
+                        <option value="torbox" {% if user_data.streaming_provider.service=='torbox' %}selected{% endif %}>Torbox (Free Quota)</option>
                         <option value="realdebrid" {% if user_data.streaming_provider.service=='realdebrid' %}selected{% endif %}>Real-Debrid (Premium)</option>
                         <option value="debridlink" {% if user_data.streaming_provider.service=='debridlink' %}selected{% endif %}>Debrid-Link (Premium)</option>
                         <option value="alldebrid" {% if user_data.streaming_provider.service=='alldebrid' %}selected{% endif %}>AllDebrid (Premium)</option>

--- a/resources/js/config_script.js
+++ b/resources/js/config_script.js
@@ -8,7 +8,8 @@ const providerSignupLinks = {
     offcloud: 'https://offcloud.com/?=9932cd9f',
     realdebrid: 'http://real-debrid.com/?id=9490816',
     debridlink: 'https://debrid-link.com/id/kHgZs',
-    alldebrid: 'https://alldebrid.com/?uid=3ndha&lang=en'
+    alldebrid: 'https://alldebrid.com/?uid=3ndha&lang=en',
+    torbox: 'https://torbox.app/'
 };
 
 // ---- OAuth-related Functions ----

--- a/streaming_providers/torbox/client.py
+++ b/streaming_providers/torbox/client.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+from streaming_providers.debrid_client import DebridClient
+from streaming_providers.exceptions import ProviderException
+
+
+class Torbox(DebridClient):
+    BASE_URL = "https://api.torbox.app/v1/api"
+
+    def initialize_headers(self):
+        self.headers = {"Authorization": f"Bearer {self.token}"}
+
+    def __del__(self):
+        pass
+
+    def _handle_service_specific_errors(self, error):
+        pass
+
+    def _make_request(
+            self,
+            method: str,
+            url: str,
+            data=None,
+            params=None,
+            is_return_none=False,
+            is_expected_to_fail=False,
+    ) -> dict:
+        params = params or {}
+        url = self.BASE_URL + url
+        return super()._make_request(
+            method, url, data, params, is_return_none, is_expected_to_fail
+        )
+
+    def add_magent_link(self, magnet_link):
+        response_data = self._make_request("POST", "/torrents/createtorrent", data={"magnet": magnet_link})
+
+        # Response when created successfully shows up as "Torrent queued successfully"
+        if "successfully" not in response_data.get("detail"):
+            raise ProviderException(
+                f"Failed to add magnet link to Torbox {response_data}",
+                "transfer_error.mp4",
+            )
+        return response_data
+
+    def get_user_torrent_list(self):
+        return self._make_request("GET", "/torrents/mylist")
+
+    def get_torrent_info(self, magnet_id):
+        response = self.get_user_torrent_list()
+        torrent_list = response.get("data", {})
+        for torrent in torrent_list:
+            if torrent.get("magnet", "") == magnet_id:
+                return torrent
+        return {}
+
+    def get_torrent_instant_availability(self):
+        return self.get_user_torrent_list().get("data", {})
+
+    def get_available_torrent(self, info_hash) -> dict[str, Any] | None:
+        response = self.get_user_torrent_list()
+        torrent_list = response.get("data", {})
+        for torrent in torrent_list:
+            if torrent.get("hash", "") == info_hash:
+                return torrent
+        return {}
+
+    def create_download_link(self, torrent_id, filename):
+        response = self._make_request(
+            "GET",
+            "/torrents/requestdl",
+            params={"token": self.token, "torrent_id": torrent_id, "file_id": filename},
+            is_expected_to_fail=True,
+        )
+        if "successfully" in response.get("detail"):
+            return response
+        raise ProviderException(
+            f"Failed to create download link from Torbox {response}",
+            "transfer_error.mp4",
+        )
+
+    def delete_torrent(self, magnet_id):
+        raise NotImplementedError

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -25,7 +25,7 @@ def get_direct_link_from_torbox(
             return response["data"]
     else:
         # If torrent doesn't exist, add it
-        _ = torbox_client.add_magent_link(magnet_link)
+        torbox_client.add_magent_link(magnet_link)
 
     # Do not wait for download completion, just let the user retry again.
     raise ProviderException(

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -1,0 +1,73 @@
+from typing import Any
+
+from db.models import Streams
+from db.schemas import UserData
+from streaming_providers.exceptions import ProviderException
+from streaming_providers.torbox.client import Torbox
+
+
+def get_direct_link_from_torbox(
+        info_hash: str,
+        magnet_link: str,
+        user_data: UserData,
+        filename: str,
+        max_retries=5,
+        retry_interval=5,
+) -> str:
+    torbox_client = Torbox(token=user_data.streaming_provider.token)
+
+    # Check if the torrent already exists
+    torrent_info = torbox_client.get_available_torrent(info_hash)
+    if torrent_info:
+        if torrent_info["download_finished"] is True and torrent_info["download_present"] is True:
+            file_id = select_file_id_from_torrent(torrent_info, filename)
+            response = torbox_client.create_download_link(torrent_info.get("id"), file_id)
+            return response["data"]
+    else:
+        # If torrent doesn't exist, add it
+        _ = torbox_client.add_magent_link(magnet_link)
+
+    # Do not wait for download completion, just let the user retry again.
+    raise ProviderException(
+        f"Torrent did not reach downloaded status.",
+        "torrent_not_downloaded.mp4",
+    )
+
+
+def update_torbox_cache_status(streams: list[Streams], user_data: UserData):
+    """Updates the cache status of streams based on Torbox's instant availability."""
+
+    try:
+        torbox_client = Torbox(token=user_data.streaming_provider.token)
+        instant_availability_data = torbox_client.get_torrent_instant_availability()
+        for stream in streams:
+            stream.cached = any(
+                torrent["download_finished"] is True and torrent["download_present"] is True
+                for torrent in instant_availability_data
+                if torrent["hash"] == stream.id
+            )
+    except ProviderException:
+        pass
+
+
+def fetch_downloaded_info_hashes_from_torbox(user_data: UserData) -> list[str]:
+    """Fetches the info_hashes of all torrents downloaded in the Torbox account."""
+    try:
+        torbox_client = Torbox(token=user_data.streaming_provider.token)
+        available_torrents = torbox_client.get_user_torrent_list()
+        if not available_torrents.get("data"):
+            return []
+        return [torrent["hash"] for torrent in available_torrents["data"]]
+
+    except ProviderException:
+        return []
+
+
+def select_file_id_from_torrent(torrent_info: dict[str, Any], filename: str) -> int:
+    """Select the file id from the torrent info."""
+    for index, file in enumerate(torrent_info["files"]):
+        if filename in file["name"]:
+            return file["id"]
+    raise ProviderException(
+        "No matching file available for this torrent", "api_error.mp4"
+    )

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -32,6 +32,10 @@ from streaming_providers.seedr.utils import (
     update_seedr_cache_status,
     fetch_downloaded_info_hashes_from_seedr,
 )
+from streaming_providers.torbox.utils import (
+    update_torbox_cache_status,
+    fetch_downloaded_info_hashes_from_torbox,
+)
 
 ia = Cinemagoer()
 
@@ -58,6 +62,7 @@ async def filter_and_sort_streams(
         "pikpak": update_pikpak_cache_status,
         "realdebrid": update_rd_cache_status,
         "seedr": update_seedr_cache_status,
+        "torbox": update_torbox_cache_status,
     }
 
     # Update cache status based on provider
@@ -225,6 +230,7 @@ async def fetch_downloaded_info_hashes(user_data: UserData) -> list[str]:
         "pikpak": fetch_downloaded_info_hashes_from_pikpak,
         "realdebrid": fetch_downloaded_info_hashes_from_rd,
         "seedr": fetch_downloaded_info_hashes_from_seedr,
+        "torbox": fetch_downloaded_info_hashes_from_torbox,
     }
 
     if fetch_downloaded_info_hashes_function := fetch_downloaded_info_hashes_functions.get(


### PR DESCRIPTION
### Changes
Integrate new streaming provider Torbox
API docs : https://documenter.getpostman.com/view/29572726/2s9YXo1zX4#intro
Site : https://torbox.app/

### Testing 
* Able to add a magnet link
* After download is finished, able to generate a URL and stream it. 

### Note
* This change deviates a bit from other implementations, after adding the magnet link, it doesn't wait to check for the state, it just raises a "Torrent did not reach downloaded status" - that is cause the API is a bit rudimentary, adding the magnet link does not return any status or id, it just says success, so let the user retry. I can however change this to get the torrent and check, but thought this is ok for now. 
* Referral link also not added, there is an explicit POST request made for referral (to the link "https://db.torbox.app/rest/v1/referrals") and hence, not adding a referral link for sign up.
* There is no API for figuring out if a torrent is cached, so it's similar to pikpak where we can only check with the list of torrents on Torbox.