### PR TITLE
Modify add magnet flow with the new API changes and add check cached endpoint check as well

### DIFF
--- a/streaming_providers/torbox/client.py
+++ b/streaming_providers/torbox/client.py
@@ -59,12 +59,9 @@ class Torbox(DebridClient):
 
     def get_torrent_instant_availability(self, torrent_hashes: list[str]):
         response = self._make_request(
-            "GET", "/torrents/checkcached", params={"hash": torrent_hashes, "format": "list"}
+            "GET", "/torrents/checkcached", params={"hash": torrent_hashes, "format": "object"}
         )
-        data = response.get("data", {})
-        if type(data) is dict and data.get("data", False) is False:
-            return []
-        return data
+        return response.get("data", {})
 
     def get_available_torrent(self, info_hash) -> dict[str, Any] | None:
         response = self.get_user_torrent_list()

--- a/streaming_providers/torbox/client.py
+++ b/streaming_providers/torbox/client.py
@@ -39,8 +39,7 @@ class Torbox(DebridClient):
             is_expected_to_fail=True
         )
 
-        detail = response_data.get("detail")
-        if type(detail) is bool and detail is False:
+        if response_data.get("detail") is False:
             raise ProviderException(
                 f"Failed to add magnet link to Torbox {response_data}",
                 "transfer_error.mp4",

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -25,7 +25,7 @@ def get_direct_link_from_torbox(
             return response["data"]
     else:
         # If torrent doesn't exist, add it
-        torbox_client.add_magent_link(magnet_link)
+        torbox_client.add_magnet_link(magnet_link)
 
     # Do not wait for download completion, just let the user retry again.
     raise ProviderException(
@@ -39,12 +39,12 @@ def update_torbox_cache_status(streams: list[Streams], user_data: UserData):
 
     try:
         torbox_client = Torbox(token=user_data.streaming_provider.token)
-        instant_availability_data = torbox_client.get_torrent_instant_availability()
+        instant_availability_data = torbox_client.get_torrent_instant_availability(
+            [stream.id for stream in streams]
+        )
         for stream in streams:
             stream.cached = any(
-                torrent["download_finished"] is True and torrent["download_present"] is True
-                for torrent in instant_availability_data
-                if torrent["hash"] == stream.id
+                torrent["hash"] == stream.id for torrent in instant_availability_data
             )
     except ProviderException:
         pass

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -43,9 +43,7 @@ def update_torbox_cache_status(streams: list[Streams], user_data: UserData):
             [stream.id for stream in streams]
         )
         for stream in streams:
-            stream.cached = any(
-                torrent["hash"] == stream.id for torrent in instant_availability_data
-            )
+            stream.cached = bool(stream.id in instant_availability_data)
     except ProviderException:
         pass
 


### PR DESCRIPTION
Torbox made some API changes in the create torrent flow, helps check if adding a magnet link has failed.

Similarly, the ability to check the cached status of a torrent is also available and hence, adding that endpoint and check as well. 