### PR TITLE
Add magnet links to bitsearch during parsing

### DIFF
--- a/scrappers/helpers.py
+++ b/scrappers/helpers.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 import cloudscraper
+import httpx
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -101,3 +102,14 @@ def get_scrapper_config(site_name: str, get_key: str) -> dict:
         config = json.load(file)
 
     return config.get(site_name, {}).get(get_key, {})
+
+
+async def add_to_bitsearch(magnet_link: str):
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://bitsearch.to/add-torrent", data={'infohash': magnet_link}
+        )
+        if response.status_code == 200:
+            logging.info(f"Added {magnet_link} to bitsearch")
+        else:
+            logging.error(f"Failed to add magnet link {magnet_link}: {response.status_code}")

--- a/scrappers/tamil_blasters.py
+++ b/scrappers/tamil_blasters.py
@@ -18,6 +18,7 @@ from scrappers.helpers import (
     get_scrapper_session,
     download_and_save_torrent,
     get_scrapper_config,
+    add_to_bitsearch,
 )
 
 HOMEPAGE = get_scrapper_config("tamil_blasters", "homepage")
@@ -92,6 +93,7 @@ async def process_movie(
 
         # Extracting torrent details
         torrent_elements = movie_page.select("a[data-fileext='torrent']")
+        magnet_elements = movie_page.select("a[class='magnet-plugin']")
 
         if not torrent_elements:
             logging.error(f"No torrents found for {page_link}")
@@ -113,6 +115,10 @@ async def process_movie(
                     exc_info=True,
                     stack_info=True,
                 )
+        if magnet_elements:
+            for magnet_element in magnet_elements:
+                magnet_link = magnet_element.get("href")
+                await add_to_bitsearch(magnet_link)
 
         return True
     except Exception as e:

--- a/scrappers/tamilmv.py
+++ b/scrappers/tamilmv.py
@@ -18,6 +18,7 @@ from scrappers.helpers import (
     get_scrapper_session,
     download_and_save_torrent,
     get_scrapper_config,
+    add_to_bitsearch,
 )
 
 HOMEPAGE = get_scrapper_config("tamilmv", "homepage")
@@ -82,6 +83,7 @@ async def process_movie(
 
         # Extracting torrent details
         torrent_elements = movie_page.select("a[data-fileext='torrent']")
+        magnet_elements = movie_page.select("a[class='skyblue-button']")
 
         if not torrent_elements:
             logging.error(f"No torrents found for {page_link}")
@@ -96,6 +98,10 @@ async def process_movie(
                 media_type=media_type,
                 page_link=page_link,
             )
+        if magnet_elements:
+            for magnet_element in magnet_elements:
+                magnet_link = magnet_element.get("href")
+                await add_to_bitsearch(magnet_link)
 
         return True
     except Exception as e:


### PR DESCRIPTION
Add magnet links to bit search during parsing - this helps in prowlarr searches, bitsearch is very fast for search and contains many torrents indexed, and has a neat API to add the infohash, so add it to bitsearch during parsing for searching in prowlarr later. 

Tested locally by running the parser on both sites and observed it being added to bitsearch as well. 