### PR TITLE
Pass in the database in the mongo URI and add torbox ref as mediafusion for sign ups

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -15,10 +15,9 @@ from db.models import (
 async def init():
     # Create Motor client
     client = motor.motor_asyncio.AsyncIOMotorClient(settings.mongo_uri)
-
     # Init beanie with the Product document class
     await init_beanie(
-        database=client.mediafusion,
+        database=client.get_default_database(),  # Note that the database needs to be passed as part of the URI
         document_models=[
             MediaFusionMovieMetaData,
             MediaFusionSeriesMetaData,

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             cpu: "500m"
         env:
           - name: MONGO_URI
-            value: "mongodb://mongodb-service:27017"
+            value: "mongodb://mongodb-service:27017/mediafusion"
           - name: SECRET_KEY
             valueFrom:
               secretKeyRef:

--- a/resources/js/config_script.js
+++ b/resources/js/config_script.js
@@ -9,7 +9,7 @@ const providerSignupLinks = {
     realdebrid: 'http://real-debrid.com/?id=9490816',
     debridlink: 'https://debrid-link.com/id/kHgZs',
     alldebrid: 'https://alldebrid.com/?uid=3ndha&lang=en',
-    torbox: 'https://torbox.app/',
+    torbox: 'https://torbox.app/login?ref=mediafusion',
     premiumize: 'https://www.premiumize.me',
 };
 


### PR DESCRIPTION
Change 1 : If someone wants to setup their DB with a different database name, it will be helpful for them to pass it in the URI, so pick the DB based on the URI instead of forcing it in code. 

Tested that it works with the current mediafusion deployment. `MONGO_URI=mongodb://localhost:27017/mediafusion` worked to connect locally.

Change 2: Pass ref as mediafusion for torbox, after talking to the torbox developer. 