### PR TITLE
Add delete functionality for Offcloud and Torbox

### DIFF
--- a/streaming_providers/mapper.py
+++ b/streaming_providers/mapper.py
@@ -11,6 +11,7 @@ from streaming_providers.debridlink.utils import (
 from streaming_providers.offcloud.utils import (
     update_oc_cache_status,
     fetch_downloaded_info_hashes_from_oc,
+    delete_all_torrents_from_oc,
 )
 from streaming_providers.pikpak.utils import (
     update_pikpak_cache_status,
@@ -40,6 +41,7 @@ from streaming_providers.seedr.utils import (
 from streaming_providers.torbox.utils import (
     update_torbox_cache_status,
     fetch_downloaded_info_hashes_from_torbox,
+    delete_all_torrents_from_torbox,
 )
 
 # Define provider-specific cache update functions
@@ -77,4 +79,6 @@ DELETE_ALL_WATCHLIST_FUNCTIONS = {
     "qbittorrent": delete_all_torrents_from_qbittorrent,
     "realdebrid": delete_all_watchlist_rd,
     "seedr": delete_all_torrents_from_seedr,
+    "offcloud": delete_all_torrents_from_oc,
+    "torbox": delete_all_torrents_from_torbox,
 }

--- a/streaming_providers/offcloud/client.py
+++ b/streaming_providers/offcloud/client.py
@@ -43,7 +43,7 @@ class OffCloud(DebridClient):
             method, url, data, params, is_return_none, is_expected_to_fail
         )
 
-    def add_magent_link(self, magnet_link):
+    def add_magnet_link(self, magnet_link):
         response_data = self._make_request("POST", "/cloud", data={"url": magnet_link})
 
         if "requestId" not in response_data:
@@ -74,7 +74,7 @@ class OffCloud(DebridClient):
     def get_available_torrent(self, info_hash) -> dict[str, Any] | None:
         available_torrents = self.get_user_torrent_list()
         for torrent in available_torrents:
-            if info_hash in torrent["originalLink"]:
+            if info_hash.casefold() in torrent["originalLink"].casefold():
                 return torrent
 
     def explore_folder_links(self, request_id):

--- a/streaming_providers/offcloud/utils.py
+++ b/streaming_providers/offcloud/utils.py
@@ -29,7 +29,7 @@ def get_direct_link_from_offcloud(
             )
     else:
         # If torrent doesn't exist, add it
-        response_data = oc_client.add_magent_link(magnet_link)
+        response_data = oc_client.add_magnet_link(magnet_link)
         request_id = response_data["requestId"]
 
     # Wait for download completion and get the direct link
@@ -68,3 +68,11 @@ def fetch_downloaded_info_hashes_from_oc(user_data: UserData) -> list[str]:
 
     except ProviderException:
         return []
+
+
+def delete_all_torrents_from_oc(user_data: UserData):
+    """Deletes all torrents from the Offcloud account."""
+    oc_client = OffCloud(token=user_data.streaming_provider.token)
+    torrents = oc_client.get_user_torrent_list()
+    for torrent in torrents:
+        oc_client.delete_torrent(torrent.get("requestId"))

--- a/streaming_providers/routes.py
+++ b/streaming_providers/routes.py
@@ -117,7 +117,7 @@ async def streaming_provider_endpoint(
             )
         elif user_data.streaming_provider.service == "offcloud":
             video_url = get_direct_link_from_offcloud(
-                info_hash, magnet_link, user_data, filename, 1, 0
+                info_hash, magnet_link, user_data, filename, 1, 0, episode=episode,
             )
         elif user_data.streaming_provider.service == "pikpak":
             video_url = await get_direct_link_from_pikpak(

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -99,3 +99,13 @@ def select_file_id_from_torrent(torrent_info: dict[str, Any], filename: str, epi
         )
 
     return selected_file["id"]
+
+
+def delete_all_torrents_from_torbox(user_data: UserData):
+    """Deletes all torrents from the Torbox account."""
+    torbox_client = Torbox(token=user_data.streaming_provider.token)
+    torrents = torbox_client.get_user_torrent_list().get("data")
+    if not torrents:
+        return
+    for torrent in torrents:
+        torbox_client.delete_torrent(torrent.get("id"))


### PR DESCRIPTION
Missed passing the episode to offcloud call in link generation as part of the previous change. 

Add delete functions to the mapper. 