### PR TITLE
Torbox delete endpoint bug fix, Optimize torbox for cached torrents to return download link in the same request

### DIFF
--- a/streaming_providers/torbox/client.py
+++ b/streaming_providers/torbox/client.py
@@ -1,3 +1,5 @@
+import json
+
 from typing import Any
 
 from streaming_providers.debrid_client import DebridClient
@@ -88,7 +90,7 @@ class Torbox(DebridClient):
     def delete_torrent(self, torrent_id):
         return self._make_request(
             "POST",
-            "torrents/controltorrent",
-            params={"token": self.token, "torrent_id": torrent_id, "operation": "Delete"}
+            "/torrents/controltorrent",
+            data=json.dumps({"torrent_id": torrent_id, "operation": "delete"})
         )
 

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -35,7 +35,17 @@ def get_direct_link_from_torbox(
             return response["data"]
     else:
         # If torrent doesn't exist, add it
-        torbox_client.add_magnet_link(magnet_link)
+        response = torbox_client.add_magnet_link(magnet_link)
+        # Response detail has "Found Cached Torrent. Using Cached Torrent." if it's a cached torrent,
+        # create download link from it directly in the same call.
+        if 'Found Cached' in response.get("detail"):
+            torrent_info = torbox_client.get_available_torrent(info_hash)
+            file_id = select_file_id_from_torrent(torrent_info, filename, episode)
+            response = torbox_client.create_download_link(
+                torrent_info.get("id"), file_id,
+            )
+
+        return response["data"]
 
     # Do not wait for download completion, just let the user retry again.
     raise ProviderException(


### PR DESCRIPTION
Small bugfix for torbox delete endpoint. For whatever reason, sending the data as json instead of dict works, possibly related to the header being set when sent as json instead of dict. 

Optimize torbox for cached torrents to return download link in the same request instead of having to retry.