### PR TITLE
Refactor poster URLs to use separate host for images

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -60,8 +60,8 @@ app.add_middleware(middleware.UserDataMiddleware)
 TEMPLATES = Jinja2Templates(directory="resources")
 DELETE_ALL_META = schemas.Meta(
     **const.DELETE_ALL_WATCHLIST_META,
-    poster=f"{settings.host_url}/static/images/delete_all_poster.jpg",
-    background=f"{settings.host_url}/static/images/delete_all_background.png",
+    poster=f"{settings.poster_host_url}/static/images/delete_all_poster.jpg",
+    background=f"{settings.poster_host_url}/static/images/delete_all_background.png",
 )
 
 DELETE_ALL_META_ITEM = {

--- a/db/config.py
+++ b/db/config.py
@@ -8,7 +8,8 @@ class Settings(BaseSettings):
     redis_url: str = "redis://redis-service:6379"
 
     # API and service URLs
-    host_url: str = "https://mediafusion.fun"
+    host_url: str
+    poster_host_url: str
     scraper_proxy_url: str | None = None
     torrentio_url: str = "https://torrentio.strem.fun"
     prowlarr_url: str = "http://prowlarr-service:9696"

--- a/db/crud.py
+++ b/db/crud.py
@@ -56,7 +56,7 @@ async def get_meta_list(
     else:
         query_filters = {"catalog": {"$in": [catalog]}}
 
-    poster_path = f"{settings.host_url}/poster/{catalog_type}/"
+    poster_path = f"{settings.poster_host_url}/poster/{catalog_type}/"
     meta_class = MediaFusionMetaData
 
     # Define the pipeline for aggregation
@@ -139,7 +139,7 @@ async def get_tv_meta_list(
     )
 
     for meta in tv_meta_list:
-        meta.poster = f"{settings.host_url}/poster/tv/{meta.id}.jpg"
+        meta.poster = f"{settings.poster_host_url}/poster/tv/{meta.id}.jpg"
 
     return tv_meta_list
 
@@ -391,7 +391,7 @@ async def get_movie_meta(meta_id: str, redis: Redis):
             "_id": meta_id,
             "type": "movie",
             "title": movie_data.title,
-            "poster": f"{settings.host_url}/poster/movie/{meta_id}.jpg",
+            "poster": f"{settings.poster_host_url}/poster/movie/{meta_id}.jpg",
             "background": movie_data.poster,
             "description": movie_data.description,
             "runtime": movie_data.runtime,
@@ -411,7 +411,7 @@ async def get_series_meta(meta_id: str):
             "_id": meta_id,
             "type": "series",
             "title": series_data.title,
-            "poster": f"{settings.host_url}/poster/series/{meta_id}.jpg",
+            "poster": f"{settings.poster_host_url}/poster/series/{meta_id}.jpg",
             "background": series_data.background or series_data.poster,
             "videos": [],
         }
@@ -704,7 +704,7 @@ async def process_search_query(
             "$set": {
                 "poster": {
                     "$concat": [
-                        f"{settings.host_url}/poster/{catalog_type}/",
+                        f"{settings.poster_host_url}/poster/{catalog_type}/",
                         "$_id",
                         ".jpg",
                     ]
@@ -753,7 +753,7 @@ async def process_tv_search_query(search_query: str) -> dict:
             "$set": {
                 "poster": {
                     "$concat": [
-                        f"{settings.host_url}/poster/tv/",
+                        f"{settings.poster_host_url}/poster/tv/",
                         "$_id",
                         ".jpg",
                     ]
@@ -942,7 +942,9 @@ async def get_events_meta_list(
         events_json = await redis.get(key)
         if events_json:
             meta_data = schemas.Meta.model_validate_json(events_json)
-            meta_data.poster = f"{settings.host_url}/poster/events/{meta_data.id}.jpg"
+            meta_data.poster = (
+                f"{settings.poster_host_url}/poster/events/{meta_data.id}.jpg"
+            )
             events.append(meta_data)
         else:
             # Cleanup: Remove expired or missing event key from the index

--- a/deployment/docker-compose/.env-sample
+++ b/deployment/docker-compose/.env-sample
@@ -1,4 +1,5 @@
 HOST_URL="https://mediafusion.local"
+POSTER_HOST_URL="https://mediafusion.local"
 MONGO_URI="mongodb://mongodb:27017/mediafusion"
 REDIS_URL="redis://redis:6379"
 PROWLARR_URL="http://prowlarr:9696"

--- a/deployment/k8s/local-deployment.yaml
+++ b/deployment/k8s/local-deployment.yaml
@@ -54,6 +54,8 @@ spec:
                 key: PROWLARR_API_KEY
           - name: HOST_URL
             value: "https://mediafusion.local"
+          - name: POSTER_HOST_URL
+            value: "https://mediafusion.local"
           - name: ENABLE_TAMILMV_SEARCH_SCRAPER
             value: "false"
           - name: PROWLARR_IMMEDIATE_MAX_PROCESS

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,8 +15,11 @@ This guide describes the environment variables available in MediaFusion for conf
 
 #### Application Settings
 
+- **addon_name** (default: `"MediaFusion"`): The name of the MediaFusion addon. You can customize this value identify the addon.
+- **logo_url** (default: GitHub RAW Addon URL): The URL of the MediaFusion logo.
 - **secret_key** (required): A secret key for securely signing the session.
-- **host_url** (default: `"https://mediafusion.fun"`): The URL where MediaFusion is hosted.
+- **host_url** (required): The URL where MediaFusion is hosted.
+- **poster_host_url** (required): The URL where MediaFusion is hosted. Use the same value as `host_url`. This setting intends to serve the poster images from the cached location.
 - **logging_level** (default: `"INFO"`): The logging level of the application.
 - **enable_tamilmv_search_scraper** (default: `False`): Toggle the TamilMV search scraper.
 - **is_scrap_from_torrentio** (default: `False`): Enable or disable scraping from Torrentio.
@@ -39,10 +42,13 @@ This guide describes the environment variables available in MediaFusion for conf
 - **prowlarr_immediate_max_process** (default: `10`) and **prowlarr_immediate_max_process_time** (default: 15): Settings related to the immediate processing of Prowlarr searches.
 - **torrentio_search_interval_days** (default: `3`): How often Torrentio searches are initiated, in days.
 - **prowlarr_live_title_search** (default: `False`): Enable or disable live title search in Prowlarr. If False, search movie/series by title in background worker So that you won't get the result at first.
+- **prowlarr_background_title_search**: Enable or disable background title search in Prowlarr.
 
 #### Content Filters
 
 - **adult_content_regex_keywords** (default: `r"(^|\b|\s)(18\+|adult|porn|sex|xxx|nude|naked|erotic|sexy|18\s*plus)(\b|\s|$|[._-])"`): The regular expression for adult content keywords.
+- **parent_guide_nudity_filter_types_regex** (default:`"Severe"`) : The regular expression for filtering nudity content types in the parent guide of IMDB data.
+- **parent_guide_certificates_filter_regex** (default:`r"X|XXX|TV-MA|18\+|18SX"`) : The regular expression for filtering certificates in the parent guide of IMDB data.
 
 #### Scheduler Crontabs
 > [!TIP]
@@ -70,6 +76,11 @@ This guide describes the environment variables available in MediaFusion for conf
 - **disable_crictime_scheduler** (default: `False`): Disable Crictime scheduler.
 - **streambtw_scheduler_crontab** (default: `"*/15 * * * *"`): Scheduler for Streambtw.
 - **disable_streambtw_scheduler** (default: `False`): Disable Streambtw scheduler.
+- **dlhd_scheduler_crontab** (default: `"25 * * * *"`): Scheduler for DLHD.
+- **disable_dlhd_scheduler**: Disable DLHD scheduler.
+- **update_imdb_data_crontab** (default: `"0 2 * * *"`): Scheduler for updating IMDb data.
+- **motogp_tgx_scheduler_crontab** (default: `"0 5 * * *"`): Scheduler for MotoGP TGX.
+- **disable_motogp_tgx_scheduler**: Disable MotoGP TGX scheduler.
 
 ### How to Configure
 


### PR DESCRIPTION
This pull request refactors the poster URLs in the code to use a separate host for images. Previously, the URLs were using the `settings.host_url` variable, but now they will use the `settings.poster_host_url` variable. This change ensures that the poster images are served from the cached location.