### PR TITLE
Proxy debrid provider via mediafusion instance

### DIFF
--- a/db/schemas.py
+++ b/db/schemas.py
@@ -146,6 +146,7 @@ class UserData(BaseModel):
     show_full_torrent_name: bool = True
     torrent_sorting_priority: list[str] = Field(default=const.TORRENT_SORTING_PRIORITY)
     api_password: str | None = None
+    proxy_debrid_stream: bool = False
 
     @model_validator(mode="after")
     def validate_selected_resolutions(self) -> "UserData":

--- a/resources/html/configure.html
+++ b/resources/html/configure.html
@@ -231,6 +231,19 @@
                             </label>
                         </div>
                     </div>
+
+                    <!-- Enable Proxy Debrid Stream Checkbox -->
+                    <div id="proxy_debrid_section" class="mb-3">
+                        <h6>Proxy debrid stream:</h6>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="proxy_debrid_stream"
+                                   id="proxy_debrid_stream" {% if user_data.streaming_provider and user_data.proxy_debrid_stream %}checked{% endif %}>
+                            <label class="form-check-label" for="proxy_debrid_stream">
+                                Proxy the video via Mediafusion for debrid <span class="bi bi-question-circle" data-bs-toggle="tooltip" data-bs-placement="top"
+                                                               title="Toggle to proxy the video via Mediafusion. This is perfect for when you want to have only one IP registered with your debrid provider."></span>
+                            </label>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Streaming Filter Configuration -->

--- a/resources/html/configure.html
+++ b/resources/html/configure.html
@@ -240,7 +240,7 @@
                                    id="proxy_debrid_stream" {% if user_data.streaming_provider and user_data.proxy_debrid_stream %}checked{% endif %}>
                             <label class="form-check-label" for="proxy_debrid_stream">
                                 Proxy the video via Mediafusion for debrid <span class="bi bi-question-circle" data-bs-toggle="tooltip" data-bs-placement="top"
-                                                               title="Toggle to proxy the video via Mediafusion. This is perfect for when you want to have only one IP registered with your debrid provider."></span>
+                                                               title="Toggle to proxy the video via Mediafusion. This is perfect for when you want to have only one IP registered with your debrid provider. Available in ElfHosted Premium & Self Hosting users."></span>
                             </label>
                         </div>
                     </div>

--- a/resources/js/config_script.js
+++ b/resources/js/config_script.js
@@ -189,11 +189,13 @@ function updateProviderFields(isChangeEvent = false) {
             setElementDisplay('qbittorrent_config', 'none');
         }
         setElementDisplay('watchlist_section', 'block');
+        setElementDisplay('proxy_debrid_section', 'block');
         watchlistLabel.textContent = `Enable ${provider.charAt(0).toUpperCase() + provider.slice(1)} Watchlist`;
     } else {
         setElementDisplay('credentials', 'none');
         setElementDisplay('token_input', 'none');
         setElementDisplay('watchlist_section', 'none');
+        setElementDisplay('proxy_debrid_section', 'none');
         setElementDisplay('qbittorrent_config', 'none');
     }
 
@@ -294,6 +296,7 @@ function getUserData() {
         }
         streamingProviderData.service = provider;
         streamingProviderData.enable_watchlist_catalogs = document.getElementById('enable_watchlist').checked;
+        streamingProviderData.proxy_debrid_stream = document.getElementById('proxy_debrid_stream').checked;
     } else {
         streamingProviderData = null;
     }
@@ -326,6 +329,7 @@ function getUserData() {
         selected_catalogs: Array.from(document.querySelectorAll('input[name="selected_catalogs"]:checked')).map(el => el.value),
         selected_resolutions: Array.from(document.querySelectorAll('input[name="selected_resolutions"]:checked')).map(el => el.value),
         enable_catalogs: document.getElementById('enable_catalogs').checked,
+        proxy_debrid_stream: document.getElementById('proxy_debrid_stream').checked,
         max_size: maxSizeBytes,
         max_streams_per_resolution: maxStreamsPerResolution,
         torrent_sorting_priority: selectedSortingOptions,

--- a/streaming_providers/routes.py
+++ b/streaming_providers/routes.py
@@ -1,13 +1,16 @@
 import asyncio
 import logging
 
+import aiohttp
+import httpx
 from fastapi import (
     Request,
     Response,
     HTTPException,
     APIRouter,
 )
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, StreamingResponse
+from starlette.background import BackgroundTask
 from redis.asyncio import Redis
 
 from db import crud
@@ -135,6 +138,83 @@ async def streaming_provider_endpoint(
         url=video_url, headers=response.headers, status_code=redirect_status_code
     )
 
+
+# This endpoint is to proxy the debrid provider via this instance.
+@router.head("/{secret_str}/proxy_stream", tags=["streaming_provider"])
+@router.get("/{secret_str}/proxy_stream", tags=["streaming_provider"])
+@wrappers.exclude_rate_limit
+@wrappers.auth_required
+async def proxy_streaming_provider_endpoint(
+    secret_str: str,
+    info_hash: str,
+    response: Response,
+    request: Request,
+    season: int = None,
+    episode: int = None,
+):
+    response.headers.update(const.NO_CACHE_HEADERS)
+
+    user_data = request.scope.get("user", crypto.decrypt_user_data(secret_str))
+    if not user_data.streaming_provider:
+        raise HTTPException(status_code=400, detail="No streaming provider set.")
+
+    streaming_provider_response = await streaming_provider_endpoint(
+        secret_str, info_hash, response, request, season, episode)
+    if streaming_provider_response.status_code != 302:
+        return streaming_provider_response
+
+    # Validate if proxying is allowed
+    if (
+            not settings.is_public_instance
+            and user_data.proxy_debrid_stream
+            and user_data.streaming_provider
+    ):
+        video_url = streaming_provider_response.headers.get("location", "")
+        async with aiohttp.ClientSession() as session:
+            class Streamer:
+                def __init__(self):
+                    self.response = None
+
+                async def stream_content(self, headers: dict):
+                    async with httpx.AsyncClient() as client:
+                        async with client.stream(
+                                "GET", video_url, headers=headers
+                        ) as self.response:
+                            async for chunk in self.response.aiter_raw():
+                                yield chunk
+
+                async def close(self):
+                    if self.response is not None:
+                        await self.response.aclose()
+
+            range_content = None
+            range_header = request.headers.get("range")
+            if range_header:
+                range_value = range_header.strip().split("=")[1]
+                start, end = range_value.split("-")
+                start = int(start)
+                end = int(end) if end else ""
+                range_content = f"bytes={start}-{end}"
+
+            async with await session.get(
+                    video_url, headers={"Range": range_content},
+            ) as response:
+                if response.status == 206:
+                    streamer = Streamer()
+
+                    return StreamingResponse(
+                        streamer.stream_content({"Range": range_content}),
+                        status_code=206,
+                        headers={
+                            "Content-Range": response.headers["Content-Range"],
+                            "Content-Length": response.headers["Content-Length"],
+                            "Accept-Ranges": "bytes",
+                        },
+                        background=BackgroundTask(await streamer.close()),
+                    )
+            return
+
+    return streaming_provider_response
 
 @router.get("/{secret_str}/delete_all_watchlist", tags=["streaming_provider"])
 @wrappers.exclude_rate_limit

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -121,11 +121,11 @@ async def parse_stream_data(
     )
 
     has_streaming_provider = user_data.streaming_provider is not None
-    base_proxy_url_template = (
-        f"{settings.host_url}/streaming_provider/{secret_str}/stream?info_hash={{}}"
-        if has_streaming_provider
-        else None
-    )
+    base_proxy_url_template = None
+    if has_streaming_provider:
+        base_proxy_url_template = f"{settings.host_url}/streaming_provider/{secret_str}/stream?info_hash={{}}"
+        if not settings.is_public_instance and user_data.proxy_debrid_stream:
+            base_proxy_url_template = f"{settings.host_url}/streaming_provider/{secret_str}/proxy_stream?info_hash={{}}"
 
     for stream_data in streams:
         episode_data = stream_data.get_episode(season, episode)

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -124,7 +124,7 @@ async def parse_stream_data(
     base_proxy_url_template = None
     if has_streaming_provider:
         base_proxy_url_template = f"{settings.host_url}/streaming_provider/{secret_str}/stream?info_hash={{}}"
-        if not settings.is_public_instance and user_data.proxy_debrid_stream:
+        if  settings.is_public_instance is False and user_data.proxy_debrid_stream is True:
             base_proxy_url_template = f"{settings.host_url}/streaming_provider/{secret_str}/proxy_stream?info_hash={{}}"
 
     for stream_data in streams:


### PR DESCRIPTION
Takes inspiration from comet to proxy debrid via the mediafusion instance.

Only allowed on hosted instance, not for public instance. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Proxy debrid stream" option in the configuration settings, allowing users to proxy video streams via Mediafusion for debrid providers.

- **Enhancements**
  - Improved streaming functionality with a new endpoint for proxying streaming content, including support for range requests and background tasks.

- **UI Updates**
  - Introduced a new section in the configuration interface for enabling or disabling the "Proxy debrid stream" feature.
  - Enhanced display logic to show or hide the "Proxy debrid stream" settings based on user selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->