### PR TITLE
Update Max File Size Slider

### DIFF
--- a/resources/html/configure.html
+++ b/resources/html/configure.html
@@ -266,8 +266,8 @@
                         <h6>Set File Size Filter: <span class="bi bi-question-circle" data-bs-toggle="tooltip" data-bs-placement="top"
                                                         title="Select the file size range for the streams. Slide to the end for no limit."></span></h6>
                         <!-- Slider for the file size -->
-                        <input type="range" class="form-range" id="max_size_slider" name="size_slider" min="0" max="21000000000"
-                               value="{{ user_data.max_size if user_data.max_size < 21000000000 else 21000000000 }}" step="1000000">
+                        <input type="range" class="form-range" id="max_size_slider" name="size_slider" min="0" max="43000000000"
+                               value="{{ user_data.max_size if user_data.max_size < 43000000000 else 43000000000 }}" step="100000000">
                         <label for="max_size_slider">Max File Size:</label>
                         <span id="max_size_output">Unlimited</span>
                     </div>


### PR DESCRIPTION
The FileSize Slider currently has range 0-20GB and very small step size. But several high quality streams are in the range of 20-35GB.

Following changes are included in this PR:
  - Change MaxSize to ~40GB
  - Change StepSize to ~100MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased maximum file size limit in the configuration settings to 43 GB, allowing users to handle larger files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->