### PR TITLE
Fallback imdb metadata scraping via cinemeta & Scrapy Ratelimit middleware & metadata empty cache bugfixes

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -161,7 +161,7 @@ async def get_movie_data_by_id(movie_id: str) -> Optional[MediaFusionMovieMetaDa
     movie_data = await MediaFusionMovieMetaData.get(movie_id)
     # store it in the db for feature reference.
     if not movie_data and movie_id.startswith("tt"):
-        movie = await get_imdb_movie_data(movie_id)
+        movie = await get_imdb_movie_data(movie_id, "movie")
         if not movie:
             return None
 
@@ -208,7 +208,7 @@ async def get_series_data_by_id(
     )
 
     if not series_data and series_id.startswith("tt"):
-        series = await get_imdb_movie_data(series_id)
+        series = await get_imdb_movie_data(series_id, "series")
         if not series:
             return None
 

--- a/mediafusion_scrapy/pipelines/sport_video_parser_pipeline.py
+++ b/mediafusion_scrapy/pipelines/sport_video_parser_pipeline.py
@@ -21,7 +21,7 @@ class SportVideoParserPipeline:
 
     def process_item(self, item, spider):
         adapter = ItemAdapter(item)
-        if "title" not in adapter:
+        if "title" not in adapter or "torrent_name" not in adapter:
             raise DropItem(f"title not found in item: {item}")
 
         match = self.title_regex.search(adapter["title"]) or self.title_regex.search(

--- a/mediafusion_scrapy/settings.py
+++ b/mediafusion_scrapy/settings.py
@@ -50,9 +50,9 @@ SPIDER_MIDDLEWARES = {
 
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
-# DOWNLOADER_MIDDLEWARES = {
-#    "mediafusion_scrapy.middlewares.MediafusionScrapyDownloaderMiddleware": 543,
-# }
+DOWNLOADER_MIDDLEWARES = {
+    "mediafusion_scrapy.middlewares.TooManyRequestsRetryMiddleware": 543,
+}
 
 # Enable or disable extensions
 # See https://docs.scrapy.org/en/latest/topics/extensions.html
@@ -86,7 +86,7 @@ HTTPCACHE_EXPIRATION_SECS = (
     900  # 15 minutes to avoid a multiple scraping task of same time.
 )
 HTTPCACHE_DIR = "httpcache"
-HTTPCACHE_IGNORE_HTTP_CODES = []
+HTTPCACHE_IGNORE_HTTP_CODES = [500, 502, 503, 504, 522, 524, 408, 429]
 HTTPCACHE_STORAGE = "scrapy.extensions.httpcache.FilesystemCacheStorage"
 # HTTPCACHE_POLICY = "scrapy.extensions.httpcache.RFC2616Policy"
 
@@ -97,3 +97,15 @@ FEED_EXPORT_ENCODING = "utf-8"
 LOG_LEVEL = "DEBUG"
 
 STATS_CLASS = "mediafusion_scrapy.custom_stats.RedisStatsCollector"
+
+RETRY_ENABLED = True
+RETRY_HTTP_CODES = [
+    500,
+    502,
+    503,
+    504,
+    522,
+    524,
+    408,
+]  # 429 is handled by the middleware
+RETRY_TIMES = 5

--- a/mediafusion_scrapy/spiders/arab_torrents.py
+++ b/mediafusion_scrapy/spiders/arab_torrents.py
@@ -16,8 +16,6 @@ class ArabTorrentSpider(scrapy.Spider):
             "mediafusion_scrapy.pipelines.MovieStorePipeline": 200,
             "mediafusion_scrapy.pipelines.SeriesStorePipeline": 300,
         },
-        "RETRY_HTTP_CODES": [500, 502, 503, 504, 522, 524, 408, 429],
-        "RETRY_TIMES": 5,
     }
 
     def __init__(

--- a/mediafusion_scrapy/spiders/common.py
+++ b/mediafusion_scrapy/spiders/common.py
@@ -19,8 +19,6 @@ class CommonTamilSpider(scrapy.Spider):
             "mediafusion_scrapy.pipelines.SeriesStorePipeline": 300,
             "mediafusion_scrapy.pipelines.RedisCacheURLPipeline": 400,
         },
-        "RETRY_HTTP_CODES": [500, 502, 503, 504, 522, 524, 408, 429],
-        "RETRY_TIMES": 5,
     }
 
     def __init__(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for data retrieval processes, improving application robustness.
	- Introduced a new middleware to manage HTTP 429 responses, allowing for retries with exponential backoff.
	- Added functionality to fetch metadata from an external Cinemeta API for movies and TV series.
  
- **Bug Fixes**
	- Improved validation checks for incoming items in the processing pipeline to ensure required fields are present.

- **Chores**
	- Updated settings for HTTP error handling and caching strategies to enhance resilience during scraping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->