### PR TITLE
Modify torbox to use utils and check filename for OC to prevent from crashing out.

### DIFF
--- a/streaming_providers/offcloud/client.py
+++ b/streaming_providers/offcloud/client.py
@@ -86,9 +86,10 @@ class OffCloud(DebridClient):
 
         links = self.explore_folder_links(request_id)
 
-        exact_match = next((link for link in links if filename in link), None)
-        if exact_match:
-            return exact_match
+        if filename:
+            exact_match = next((link for link in links if filename in link), None)
+            if exact_match:
+                return exact_match
 
         # Fuzzy matching as a fallback
         for link in links:


### PR DESCRIPTION
If the filename is None, the flow gets interrupted in the middle, add a check to ensure it picks the largest file for OC, and refactor TB to use the utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `filename` parameter in download link creation and file selection processes, preventing errors when `filename` is invalid.

- **Refactor**
	- Enhanced logic for selecting file IDs from torrents by introducing index-based selection, streamlining the process and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->