### PR TITLE
Add StremThru as streaming provider

### DIFF
--- a/db/schemas.py
+++ b/db/schemas.py
@@ -137,7 +137,9 @@ class StreamingProvider(BaseModel):
         "torbox",
         "premiumize",
         "qbittorrent",
+        "stremthru",
     ] = Field(alias="sv")
+    url: HttpUrl | None = Field(default=None, alias="u")
     token: str | None = Field(default=None, alias="tk")
     email: str | None = Field(default=None, alias="em")
     password: str | None = Field(default=None, alias="pw")

--- a/resources/css/styles.css
+++ b/resources/css/styles.css
@@ -372,7 +372,7 @@ input[type="text"]:focus, input[type="password"]:focus, select.form-control:focu
     font-size: 1rem;
 }
 
-#signup_section, #oauth_section, #token_input {
+#service_url_section, #signup_section, #oauth_section, #token_input {
     margin-top: 1rem;
 }
 

--- a/resources/html/configure.html
+++ b/resources/html/configure.html
@@ -63,7 +63,18 @@
                         <option value="premiumize" {% if user_data.streaming_provider.service=='premiumize' %}selected{% endif %}>Premiumize (Premium)</option>
                         <option value="alldebrid" {% if user_data.streaming_provider.service=='alldebrid' %}selected{% endif %}>AllDebrid (Premium)</option>
                         <option value="qbittorrent" {% if user_data.streaming_provider.service=='qbittorrent' %}selected{% endif %}>qBittorrent - WebDav (Free/Premium)</option>
+                        <option value="stremthru" {% if user_data.streaming_provider.service=='stremthru' %}selected{% endif %}>StremThru (Interface)</option>
                     </select>
+
+                    <!-- Service URL -->
+                    <div id="service_url_section" style="display:none" class="mb-4">
+                        <label for="service_url">Service URL:</label>
+                        <input class="form-control" type="text" id="service_url" name="service_url" placeholder="https://" aria-label="Service URL"
+                               value="{{ user_data.streaming_provider.url if user_data.streaming_provider.url else '' }}">
+                        <div class="invalid-feedback">
+                            Service URL should be valid.
+                        </div>
+                    </div>
 
                     <!-- Affiliate Signup Links -->
                     <div id="signup_section" style="display:none" class="mb-4">

--- a/streaming_providers/mapper.py
+++ b/streaming_providers/mapper.py
@@ -61,6 +61,13 @@ from streaming_providers.torbox.utils import (
     get_video_url_from_torbox,
     validate_torbox_credentials,
 )
+from streaming_providers.stremthru.utils import (
+    update_st_cache_status,
+    fetch_downloaded_info_hashes_from_st,
+    delete_all_torrents_from_st,
+    get_video_url_from_stremthru,
+    validate_stremthru_credentials,
+)
 
 # Define provider-specific cache update functions
 CACHE_UPDATE_FUNCTIONS = {
@@ -73,6 +80,7 @@ CACHE_UPDATE_FUNCTIONS = {
     "torbox": update_torbox_cache_status,
     "premiumize": update_pm_cache_status,
     "qbittorrent": update_qbittorrent_cache_status,
+    "stremthru": update_st_cache_status,
 }
 
 # Define provider-specific downloaded info hashes fetch functions
@@ -86,6 +94,7 @@ FETCH_DOWNLOADED_INFO_HASHES_FUNCTIONS = {
     "torbox": fetch_downloaded_info_hashes_from_torbox,
     "premiumize": fetch_downloaded_info_hashes_from_premiumize,
     "qbittorrent": fetch_info_hashes_from_webdav,
+    "stremthru": fetch_downloaded_info_hashes_from_st,
 }
 
 
@@ -99,6 +108,7 @@ DELETE_ALL_WATCHLIST_FUNCTIONS = {
     "seedr": delete_all_torrents_from_seedr,
     "offcloud": delete_all_torrents_from_oc,
     "torbox": delete_all_torrents_from_torbox,
+    "stremthru": delete_all_torrents_from_st,
 }
 
 
@@ -112,6 +122,7 @@ GET_VIDEO_URL_FUNCTIONS = {
     "realdebrid": get_video_url_from_realdebrid,
     "seedr": get_video_url_from_seedr,
     "torbox": get_video_url_from_torbox,
+    "stremthru": get_video_url_from_stremthru,
 }
 
 
@@ -125,4 +136,5 @@ VALIDATE_CREDENTIALS_FUNCTIONS = {
     "realdebrid": validate_realdebrid_credentials,
     "seedr": validate_seedr_credentials,
     "torbox": validate_torbox_credentials,
+    "stremthru": validate_stremthru_credentials,
 }

--- a/streaming_providers/stremthru/client.py
+++ b/streaming_providers/stremthru/client.py
@@ -1,0 +1,122 @@
+from typing import Any, Optional
+
+from streaming_providers.debrid_client import DebridClient
+from streaming_providers.exceptions import ProviderException
+
+
+class StremThruError(Exception):
+    def __init__(self, error: dict[str, Any]):
+        self.type = error.get("type", "")
+        self.code = error.get("code", "")
+        self.message = error.get("message", "")
+        self.store_name = error.get("store_name", "")
+
+
+class StremThru(DebridClient):
+    AGENT = "mediafusion"
+
+    def __init__(self, url: str, token: str, **kwargs):
+        self.BASE_URL = url
+        super().__init__(token)
+
+    async def initialize_headers(self):
+        self.headers = {
+            "Proxy-Authorization": f"Basic {self.token}",
+            "User-Agent": self.AGENT,
+        }
+
+    def __del__(self):
+        pass
+
+    async def _handle_service_specific_errors(self, error_data: dict, status_code: int):
+        pass
+
+    async def _make_request(
+        self,
+        method: str,
+        url: str,
+        data: Optional[dict] = None,
+        json: Optional[dict] = None,
+        params: Optional[dict] = None,
+        is_return_none: bool = False,
+        is_expected_to_fail: bool = False,
+        retry_count: int = 0,
+    ) -> dict[str, Any]:
+        params = params or {}
+        url = self.BASE_URL + url
+        res = await super()._make_request(
+            method,
+            url,
+            data,
+            json,
+            params,
+            is_return_none,
+            is_expected_to_fail,
+            retry_count,
+        )
+        if res.get("error", None):
+            if is_expected_to_fail:
+                return res
+            error_message = res.get("error", "unknown error")
+            raise ProviderException(str(error_message), "api_error.mp4")
+        return res.get("data")
+
+    @staticmethod
+    def _validate_error_response(response_data: dict):
+        if response_data.get("error", None):
+            raise ProviderException(
+                f"Failed request to StremThru {response_data['error']}",
+                "transfer_error.mp4",
+            )
+
+    async def add_magnet_link(self, magnet_link):
+        response_data = await self._make_request(
+            "POST", "/v0/store/magnets", data={"magnet": magnet_link}
+        )
+        self._validate_error_response(response_data)
+        return response_data["data"]
+
+    async def get_user_torrent_list(self):
+        return await self._make_request("GET", "/v0/store/magnets")
+
+    async def get_torrent_info(self, torrent_id):
+        response = await self._make_request("GET", "/v0/store/magnets/" + torrent_id)
+        return response.get("data", {})
+
+    async def get_torrent_instant_availability(self, magnet_links: list[str]):
+        return await self._make_request(
+            "GET", "/v0/store/magnets/check", params={"magnet": ",".join(magnet_links)}
+        )
+
+    async def get_available_torrent(self, info_hash) -> dict[str, Any] | None:
+        available_torrents = await self.get_user_torrent_list()
+        self._validate_error_response(available_torrents)
+        if not available_torrents.get("data", None):
+            return None
+        for torrent in available_torrents["data"]["items"]:
+            if torrent["hash"] == info_hash:
+                return torrent
+
+    async def create_download_link(self, link):
+        response = await self._make_request(
+            "POST",
+            "/v0/store/link/generate",
+            data={"link": link},
+            is_expected_to_fail=True,
+        )
+        if response.get("data", None):
+            return response["data"]
+        error_message = response.get("error", "unknown error")
+        raise ProviderException(
+            f"Failed to create download link from StremThru {error_message}",
+            "transfer_error.mp4",
+        )
+
+    async def delete_torrent(self, magnet_id):
+        return await self._make_request(
+            "DELETE",
+            "/v0/store/magnets/" + magnet_id,
+        )
+
+    async def get_user_info(self):
+        return await self._make_request("GET", "/v0/store/user")

--- a/streaming_providers/stremthru/client.py
+++ b/streaming_providers/stremthru/client.py
@@ -31,6 +31,9 @@ class StremThru(DebridClient):
     async def _handle_service_specific_errors(self, error_data: dict, status_code: int):
         pass
 
+    async def disable_access_token(self):
+        pass
+
     async def _make_request(
         self,
         method: str,
@@ -44,7 +47,7 @@ class StremThru(DebridClient):
     ) -> dict[str, Any]:
         params = params or {}
         url = self.BASE_URL + url
-        res = await super()._make_request(
+        response = await super()._make_request(
             method,
             url,
             data,
@@ -54,12 +57,12 @@ class StremThru(DebridClient):
             is_expected_to_fail,
             retry_count,
         )
-        if res.get("error", None):
+        if response.get("error"):
             if is_expected_to_fail:
-                return res
-            error_message = res.get("error", "unknown error")
-            raise ProviderException(str(error_message), "api_error.mp4")
-        return res.get("data")
+                return response
+            error_message = response.get("error", "unknown error")
+            raise ProviderException(error_message, "api_error.mp4")
+        return response.get("data")
 
     @staticmethod
     def _validate_error_response(response_data: dict):
@@ -91,7 +94,7 @@ class StremThru(DebridClient):
     async def get_available_torrent(self, info_hash) -> dict[str, Any] | None:
         available_torrents = await self.get_user_torrent_list()
         self._validate_error_response(available_torrents)
-        if not available_torrents.get("data", None):
+        if not available_torrents.get("data"):
             return None
         for torrent in available_torrents["data"]["items"]:
             if torrent["hash"] == info_hash:
@@ -104,7 +107,7 @@ class StremThru(DebridClient):
             data={"link": link},
             is_expected_to_fail=True,
         )
-        if response.get("data", None):
+        if response.get("data"):
             return response["data"]
         error_message = response.get("error", "unknown error")
         raise ProviderException(

--- a/streaming_providers/stremthru/utils.py
+++ b/streaming_providers/stremthru/utils.py
@@ -1,0 +1,132 @@
+import asyncio
+
+from db.models import TorrentStreams
+from db.schemas import UserData
+from streaming_providers.exceptions import ProviderException
+from streaming_providers.parser import select_file_index_from_torrent
+from streaming_providers.stremthru.client import StremThru
+
+
+def _get_client(user_data: UserData) -> StremThru:
+    return StremThru(
+        url=user_data.streaming_provider.url,
+        token=user_data.streaming_provider.token,
+    )
+
+
+async def get_torrent_info(st_client, info_hash):
+    torrent_info = await st_client.get_available_torrent(info_hash)
+    if torrent_info and torrent_info["status"] == "downloaded":
+        return torrent_info
+    return None
+
+
+async def add_new_torrent(st_client, magnet_link):
+    response_data = await st_client.add_magnet_link(magnet_link)
+    return response_data["id"]
+
+
+async def wait_for_download_and_get_link(
+    st_client, torrent_id, filename, file_index, episode, max_retries, retry_interval
+):
+    torrent_info = await st_client.wait_for_status(
+        torrent_id, "downloaded", max_retries, retry_interval
+    )
+    file_index = await select_file_index_from_torrent(
+        torrent_info,
+        filename,
+        episode,
+    )
+    response = await st_client.create_download_link(
+        torrent_info["files"][file_index]["link"]
+    )
+    return response["link"]
+
+
+async def get_video_url_from_stremthru(
+    info_hash: str,
+    magnet_link: str,
+    user_data: UserData,
+    filename: str,
+    user_ip: str,
+    file_index: int,
+    episode: int = None,
+    max_retries=5,
+    retry_interval=5,
+    **kwargs,
+) -> str:
+    async with _get_client(user_data) as st_client:
+        torrent_id = await add_new_torrent(st_client, magnet_link)
+
+        return await wait_for_download_and_get_link(
+            st_client,
+            torrent_id,
+            filename,
+            file_index,
+            episode,
+            max_retries,
+            retry_interval,
+        )
+
+
+async def update_st_cache_status(
+    streams: list[TorrentStreams], user_data: UserData, user_ip: str, **kwargs
+):
+    """Updates the cache status of streams based on StremThru's instant availability."""
+
+    try:
+        async with _get_client(user_data) as st_client:
+            instant_availability_data = (
+                await st_client.get_torrent_instant_availability(
+                    [stream.id for stream in streams]
+                )
+            )
+            for stream in streams:
+                stream.cached = any(
+                    torrent["status"] == "cached"
+                    for torrent in instant_availability_data["items"]
+                    if torrent.get("hash") == stream.id
+                )
+
+    except ProviderException:
+        pass
+
+
+async def fetch_downloaded_info_hashes_from_st(
+    user_data: UserData, user_ip: str, **kwargs
+) -> list[str]:
+    """Fetches the info_hashes of all torrents downloaded in the StremThru account."""
+    try:
+        async with _get_client(user_data) as st_client:
+            available_torrents = await st_client.get_user_torrent_list()
+            return [torrent["hash"] for torrent in available_torrents["items"]]
+
+    except ProviderException:
+        return []
+
+
+async def delete_all_torrents_from_st(user_data: UserData, user_ip: str, **kwargs):
+    """Deletes all torrents from the StremThru account."""
+    async with _get_client(user_data) as st_client:
+        torrents = await st_client.get_user_torrent_list()
+        await asyncio.gather(
+            *[st_client.delete_torrent(torrent["id"]) for torrent in torrents["items"]]
+        )
+
+
+async def validate_stremthru_credentials(user_data: UserData, user_ip: str) -> dict:
+    """Validates the StremThru credentials."""
+    try:
+        async with _get_client(user_data) as client:
+            response = await client.get_user_info()
+            if response:
+                return {"status": "success"}
+            return {
+                "status": "error",
+                "message": "Invalid StremThru credentials.",
+            }
+    except ProviderException as error:
+        return {
+            "status": "error",
+            "message": f"Failed to verify StremThru credential, error: {error.message}",
+        }

--- a/streaming_providers/stremthru/utils.py
+++ b/streaming_providers/stremthru/utils.py
@@ -27,7 +27,7 @@ async def add_new_torrent(st_client, magnet_link):
 
 
 async def wait_for_download_and_get_link(
-    st_client, torrent_id, filename, file_index, episode, max_retries, retry_interval
+    st_client, torrent_id, filename, episode, max_retries, retry_interval
 ):
     torrent_info = await st_client.wait_for_status(
         torrent_id, "downloaded", max_retries, retry_interval
@@ -44,12 +44,9 @@ async def wait_for_download_and_get_link(
 
 
 async def get_video_url_from_stremthru(
-    info_hash: str,
     magnet_link: str,
     user_data: UserData,
     filename: str,
-    user_ip: str,
-    file_index: int,
     episode: int = None,
     max_retries=5,
     retry_interval=5,
@@ -62,7 +59,6 @@ async def get_video_url_from_stremthru(
             st_client,
             torrent_id,
             filename,
-            file_index,
             episode,
             max_retries,
             retry_interval,
@@ -70,7 +66,7 @@ async def get_video_url_from_stremthru(
 
 
 async def update_st_cache_status(
-    streams: list[TorrentStreams], user_data: UserData, user_ip: str, **kwargs
+    streams: list[TorrentStreams], user_data: UserData, **kwargs
 ):
     """Updates the cache status of streams based on StremThru's instant availability."""
 
@@ -93,7 +89,7 @@ async def update_st_cache_status(
 
 
 async def fetch_downloaded_info_hashes_from_st(
-    user_data: UserData, user_ip: str, **kwargs
+    user_data: UserData, **kwargs
 ) -> list[str]:
     """Fetches the info_hashes of all torrents downloaded in the StremThru account."""
     try:
@@ -105,7 +101,7 @@ async def fetch_downloaded_info_hashes_from_st(
         return []
 
 
-async def delete_all_torrents_from_st(user_data: UserData, user_ip: str, **kwargs):
+async def delete_all_torrents_from_st(user_data: UserData, **kwargs):
     """Deletes all torrents from the StremThru account."""
     async with _get_client(user_data) as st_client:
         torrents = await st_client.get_user_torrent_list()
@@ -114,7 +110,7 @@ async def delete_all_torrents_from_st(user_data: UserData, user_ip: str, **kwarg
         )
 
 
-async def validate_stremthru_credentials(user_data: UserData, user_ip: str) -> dict:
+async def validate_stremthru_credentials(user_data: UserData, **kwargs) -> dict:
     """Validates the StremThru credentials."""
     try:
         async with _get_client(user_data) as client:

--- a/utils/const.py
+++ b/utils/const.py
@@ -129,6 +129,7 @@ TORRENT_SORTING_PRIORITY_OPTIONS = TORRENT_SORTING_PRIORITY
 STREAMING_SERVICE_REQUIREMENTS = {
     "pikpak": ["email", "password"],
     "qbittorrent": ["qbittorrent_config"],
+    "stremthru": ["url", "token"],
     "default": ["token"],
 }
 


### PR DESCRIPTION
StremThru: https://github.com/MunifTanjim/stremthru

Example Config for StremThru:

```env
STREMTHRU_PROXY_AUTH=user-one:password-one,user-two:password-two                                                                 
STREMTHRU_STORE_AUTH="*:realdebrid:rd-api-key-one,user-two:realdebrid:rd-api-key-two"
```

Run by following: https://github.com/MunifTanjim/stremthru?tab=readme-ov-file#usage




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new streaming provider option, "StremThru," allowing users to configure additional settings including a Service URL.
	- Added fields for user credentials (email, password) and options for enabling watchlist catalogs.
	- Enhanced validation for the Service URL input to ensure proper formatting.

- **UI/UX Improvements**
	- Updated the configuration interface to include a new section for entering the Service URL, which is displayed based on user selection.
	- Adjusted CSS styles to accommodate new UI elements.

- **Bug Fixes**
	- Improved handling of provider-specific errors and validation for user input related to the new streaming service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->