### PR TITLE
Scrape from Mediafusion instance

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -47,6 +47,11 @@ class Settings(BaseSettings):
     torrentio_search_interval_days: int = 3
     torrentio_url: str = "https://torrentio.strem.fun"
 
+    # Mediafusion Settings
+    is_scrap_from_mediafusion: bool = False
+    mediafusion_search_interval_days: int = 3
+    mediafusion_url: str = "https://mediafusion.elfhosted.com"
+
     # Zilean Settings
     is_scrap_from_zilean: bool = False
     zilean_search_interval_hour: int = 24

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ These URLs define the locations of various external services used by MediaFusion
 - **poster_host_url** (default: Use the Host URL value): The URL where poster images are served from. Use the same value as `host_url` if posters are served from the same location.
 - **scraper_proxy_url**: The proxy URL for the scraper, if any.
 - **torrentio_url** (default: `"https://torrentio.strem.fun"`): The Torrentio / KightCrawler URL.
+- **mediafusion_url** (default: `"https://mediafusion.elfhosted.com"`): The Mediafusion URL.
 - **playwright_cdp_url** (default: `"ws://browserless:3000?blockAds=true&stealth=true"`): The URL for the Playwright CDP (Chrome DevTools Protocol) service.
 - **flaresolverr_url** (default: `"http://flaresolverr:8191/v1"`): The URL for the FlareSolverr service.
 
@@ -72,6 +73,7 @@ These settings define where MediaFusion looks for its configuration files.
 These boolean flags control various features of MediaFusion.
 
 - **is_scrap_from_torrentio** (default: `False`): Enable or disable scraping from Torrentio.
+- **is_scrap_from_mediafusion** (default: `False`): Enable or disable scraping from Mediafusion. Currently supports scraping movies and series only.
 - **is_scrap_from_zilean** (default: `False`): Enable or disable scraping from Zilean.
 - **enable_rate_limit** (default: `True`): Enable or disable rate limiting.
 - **validate_m3u8_urls_liveness** (default: `True`): Enable or disable the validation of M3U8 URLs for liveness.
@@ -88,6 +90,7 @@ Settings related to content filtering and moderation.
 These settings control various time-based behaviors in the application.
 
 - **torrentio_search_interval_days** (default: 3): How often Torrentio searches are initiated, in days.
+- **mediafusion_search_interval_days** (default: 3): How often Mediafusion searches are initiated, in days.
 - **meta_cache_ttl** (default: 1800): The time-to-live (TTL) for cached metadata, in seconds (30 minutes by default).
 - **worker_max_tasks_per_child** (default: 20): The maximum number of tasks per dramatiq worker child process. This setting helps prevent memory leaks.
 

--- a/scrapers/mediafusion.py
+++ b/scrapers/mediafusion.py
@@ -28,7 +28,7 @@ class MediafusionScraper(BaseScraper):
 
     @BaseScraper.cache(ttl=MEDIAFUSION_SEARCH_TTL)
     @BaseScraper.rate_limit(calls=5, period=timedelta(seconds=1))
-    async def scrape_and_parse(
+    async def _scrape_and_parse(
         self,
         metadata: MediaFusionMetaData,
         catalog_type: str,
@@ -130,7 +130,7 @@ class MediafusionScraper(BaseScraper):
                     catalog=["mediafusion_streams"],
                     seeders=parsed_data["seeders"],
                     announce_list=[
-                        tracker.lstrip("tracker:")
+                        tracker.removeprefix("tracker:")
                         for tracker in stream_data.get("sources", [])
                         if "tracker:" in tracker
                     ],

--- a/scrapers/mediafusion.py
+++ b/scrapers/mediafusion.py
@@ -1,0 +1,219 @@
+import asyncio
+import re
+from datetime import timedelta
+from typing import List, Dict, Any
+
+import PTT
+from tenacity import RetryError
+
+from db.config import settings
+from db.models import TorrentStreams, Season, Episode, MediaFusionMetaData
+from scrapers.base_scraper import BaseScraper, ScraperError
+from utils.parser import (
+    convert_size_to_bytes,
+    is_contain_18_plus_keywords,
+)
+from utils.runtime_const import MEDIAFUSION_SEARCH_TTL
+
+
+class MediafusionScraper(BaseScraper):
+    cache_key_prefix = "mediafusion"
+
+    def __init__(self):
+        super().__init__(
+            cache_key_prefix=self.cache_key_prefix, logger_name=self.__class__.__name__
+        )
+        self.base_url = settings.mediafusion_url
+        self.semaphore = asyncio.Semaphore(10)
+
+    @BaseScraper.cache(ttl=MEDIAFUSION_SEARCH_TTL)
+    @BaseScraper.rate_limit(calls=5, period=timedelta(seconds=1))
+    async def scrape_and_parse(
+        self,
+        metadata: MediaFusionMetaData,
+        catalog_type: str,
+        season: int = None,
+        episode: int = None,
+    ) -> List[TorrentStreams]:
+        url = f"{self.base_url}/stream/{catalog_type}/{metadata.id}.json"
+        job_name = f"{metadata.title}:{metadata.id}"
+        if catalog_type == "series":
+            url = f"{self.base_url}/stream/{catalog_type}/{metadata.id}:{season}:{episode}.json"
+            job_name += f":{season}:{episode}"
+
+        try:
+            response = await self.make_request(url)
+            response.raise_for_status()
+            data = response.json()
+
+            if not self.validate_response(data):
+                self.logger.warning(f"Invalid response received for {url}")
+                return []
+
+            return await self.parse_response(
+                data, metadata, catalog_type, season, episode
+            )
+        except (ScraperError, RetryError):
+            return []
+        except Exception as e:
+            self.logger.exception(f"Error occurred while fetching {url}: {e}")
+            return []
+
+    def validate_response(self, response: Dict[str, Any]) -> bool:
+        return "streams" in response and isinstance(response["streams"], list)
+
+    async def parse_response(
+        self,
+        response: Dict[str, Any],
+        metadata: MediaFusionMetaData,
+        catalog_type: str,
+        season: int = None,
+        episode: int = None,
+    ) -> List[TorrentStreams]:
+        tasks = [
+            self.process_stream(stream_data, metadata, catalog_type, season, episode)
+            for stream_data in response.get("streams", [])
+        ]
+        results = await asyncio.gather(*tasks)
+        return [stream for stream in results if stream is not None]
+
+    async def process_stream(
+        self,
+        stream_data: Dict[str, Any],
+        metadata: MediaFusionMetaData,
+        catalog_type: str,
+        season: int = None,
+        episode: int = None,
+    ) -> TorrentStreams | None:
+        async with self.semaphore:
+            try:
+                if is_contain_18_plus_keywords(stream_data["description"]):
+                    self.logger.warning(
+                        f"Stream contains 18+ keywords: {stream_data['description']}"
+                    )
+                    return None
+
+                parsed_data = self.parse_stream_title(stream_data)
+                source = (
+                    stream_data["name"].split()[0].title()
+                    if stream_data.get("name")
+                    else "Mediafusion"
+                )
+
+                if source != "Mediafusion":
+                    if not self.validate_title_and_year(
+                        parsed_data,
+                        metadata,
+                        catalog_type,
+                        parsed_data.get("torrent_name"),
+                    ):
+                        return None
+
+                stream = TorrentStreams(
+                    id=stream_data["infoHash"],
+                    meta_id=metadata.id,
+                    torrent_name=parsed_data["torrent_name"],
+                    size=parsed_data["size"],
+                    filename=parsed_data["file_name"],
+                    file_index=stream_data.get("fileIdx"),
+                    languages=parsed_data["languages"],
+                    resolution=parsed_data["metadata"].get("resolution"),
+                    codec=parsed_data["metadata"].get("codec"),
+                    quality=parsed_data["metadata"].get("quality"),
+                    audio=parsed_data["metadata"].get("audio"),
+                    source=source,
+                    catalog=["mediafusion_streams"],
+                    seeders=parsed_data["seeders"],
+                    announce_list=[
+                        tracker.lstrip("tracker:")
+                        for tracker in stream_data.get("sources", [])
+                        if "tracker:" in tracker
+                    ],
+                )
+
+                if catalog_type == "series":
+                    if seasons := parsed_data["metadata"].get("seasons"):
+                        if len(seasons) == 1:
+                            season_number = seasons[0]
+                        else:
+                            # Skip This Stream due to multiple seasons in one torrent.
+                            return None
+                    else:
+                        season_number = season
+
+                    if parsed_data["metadata"].get("episodes"):
+                        episode_data = [
+                            Episode(
+                                episode_number=episode_number,
+                                file_index=(
+                                    stream_data.get("fileIdx")
+                                    if episode_number == episode
+                                    else None
+                                ),
+                            )
+                            for episode_number in parsed_data["metadata"]["episodes"]
+                        ]
+                    else:
+                        episode_data = [
+                            Episode(
+                                episode_number=episode,
+                                file_index=stream_data.get("fileIdx"),
+                            )
+                        ]
+
+                    stream.season = Season(
+                        season_number=season_number,
+                        episodes=episode_data,
+                    )
+                    stream.filename = None
+
+                return stream
+            except Exception as e:
+                self.logger.exception(f"Error processing stream: {e}")
+                return None
+
+    def parse_stream_title(self, stream: dict) -> dict:
+        torrent_name = stream["description"].splitlines()[0]
+        metadata = PTT.parse_title(torrent_name, True)
+
+        return {
+            "torrent_name": torrent_name,
+            "title": metadata.get("title"),
+            "size": convert_size_to_bytes(self.extract_size_string(stream["description"])),
+            "seeders": self.extract_seeders(stream["description"]),
+            "languages": self.extract_languages(metadata, stream["description"]),
+            "metadata": metadata,
+            "file_name": (
+                stream.get("behaviorHints", {}).get("filename")
+            ),
+        }
+
+    @staticmethod
+    def extract_seeders(details: str) -> int:
+        seeders_match = re.search(r"👤 (\d+)", details)
+        return int(seeders_match.group(1)) if seeders_match else 0
+
+    @staticmethod
+    def extract_languages_from_title(title: str) -> list:
+        languages = []
+        if "Multi Audio" in title or "Multi Language" in title:
+            languages.append("Multi Language")
+        elif "Dual Audio" in title or "Dual Language" in title:
+            languages.append("Dual Language")
+
+        flag_emojis = re.findall(r"[\U0001F1E6-\U0001F1FF]{2}", title)
+        if flag_emojis:
+            languages.extend(flag_emojis)
+
+        return languages
+
+    def extract_languages(self, metadata: dict, title: str) -> list:
+        languages = metadata.get("languages", [])
+        if languages:
+            return languages
+        return self.extract_languages_from_title(title)
+
+    @staticmethod
+    def extract_size_string(details: str) -> str:
+        size_match = re.search(r"💾 (\d+(?:\.\d+)?\s*(GB|MB))", details, re.IGNORECASE)
+        return size_match.group(1) if size_match else ""

--- a/utils/runtime_const.py
+++ b/utils/runtime_const.py
@@ -51,6 +51,9 @@ PROWLARR_SEARCH_TTL = int(
 TORRENTIO_SEARCH_TTL = int(
     timedelta(days=settings.torrentio_search_interval_days).total_seconds()
 )
+MEDIAFUSION_SEARCH_TTL = int(
+    timedelta(days=settings.mediafusion_search_interval_days).total_seconds()
+)
 ZILEAN_SEARCH_TTL = int(
     timedelta(hours=settings.zilean_search_interval_hour).total_seconds()
 )


### PR DESCRIPTION
Add ability to scrape from mediafusion instance if needed. 

This is only doing Movies and Series, we can add tv but its complex, metadata needs to be available anyways to make any progress, so everything needs to be proxied, so for now only add movies and tv. 

For movies and tv, it looks at mf video_id too, but I am not convinced that makes sense, the mf video id in self hosted can be different to the public instance and it won't work? So better to just allow only tt video_id and remove mf video id?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for MediaFusion, including URL, scraping toggle, and search interval.
	- Added a dedicated `MediafusionScraper` class for enhanced scraping capabilities.

- **Bug Fixes**
	- Improved error handling and response validation in the scraping process.

- **Documentation**
	- Updated the MediaFusion Environment Configuration Guide to include new settings.

- **Chores**
	- Enhanced the `run_scrapers` function to integrate the new `MediafusionScraper`.
	- Added a new constant for managing the MediaFusion search interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->