### PR TITLE
Fix StremThru create download link

### DIFF
--- a/streaming_providers/stremthru/client.py
+++ b/streaming_providers/stremthru/client.py
@@ -58,9 +58,9 @@ class StremThru(DebridClient):
             is_expected_to_fail,
             retry_count,
         )
+        if is_expected_to_fail:
+            return response
         if response.get("error"):
-            if is_expected_to_fail:
-                return response
             error_message = response.get("error", "unknown error")
             raise ProviderException(
                 f"Failed request to StremThru: {str(error_message)}",
@@ -103,7 +103,7 @@ class StremThru(DebridClient):
             return response["data"]
         error_message = response.get("error", "unknown error")
         raise ProviderException(
-            f"Failed to create download link from StremThru {error_message}",
+            f"Failed to create download link from StremThru {str(error_message)}",
             "transfer_error.mp4",
         )
 


### PR DESCRIPTION
Ran `stremthru` with this config:

```
STREMTHRU_PROXY_AUTH=root:root STREMTHRU_STORE_AUTH=root:realdebrid:api-key
```

And tested with:

```py
async def run():
    async with StremThru(url="http://localhost:8080", token="root:root") as st:
        res = await st.get_user_info()
        print(res)
        res = await st.get_user_torrent_list()
        res = await st.get_available_torrent(info_hash=res["items"][0]["hash"])
        res = await st.get_torrent_info(torrent_id=res["id"])
        res = await st.create_download_link(link=res["files"][0]["link"])
        print(res)


asyncio.run(run())
```

Got the output as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for expected failures in request processing.
	- Improved clarity of error messages when exceptions are raised.

- **Bug Fixes**
	- Refined logic in error handling to bypass unnecessary exceptions for expected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->