### PR TITLE
Add torbox user IP for CDN

### DIFF
--- a/streaming_providers/torbox/client.py
+++ b/streaming_providers/torbox/client.py
@@ -107,11 +107,11 @@ class Torbox(DebridClient):
                 return torrent
         return {}
 
-    async def create_download_link(self, torrent_id, filename):
+    async def create_download_link(self, torrent_id, filename, user_ip):
         response = await self._make_request(
             "GET",
             "/torrents/requestdl",
-            params={"token": self.token, "torrent_id": torrent_id, "file_id": filename},
+            params={"token": self.token, "torrent_id": torrent_id, "file_id": filename, "user_ip": user_ip},
             is_expected_to_fail=True,
         )
         if "successfully" in response.get("detail"):

--- a/streaming_providers/torbox/utils.py
+++ b/streaming_providers/torbox/utils.py
@@ -14,6 +14,7 @@ async def get_video_url_from_torbox(
     magnet_link: str,
     user_data: UserData,
     filename: str,
+    user_ip: str,
     episode: Optional[int] = None,
     **kwargs: Any,
 ) -> str:
@@ -31,6 +32,7 @@ async def get_video_url_from_torbox(
                 response = await torbox_client.create_download_link(
                     torrent_info.get("id", ""),
                     file_id,
+                    user_ip,
                 )
                 return response["data"]
         else:
@@ -47,6 +49,7 @@ async def get_video_url_from_torbox(
                     response = await torbox_client.create_download_link(
                         torrent_info.get("id", ""),
                         file_id,
+                        user_ip,
                     )
                     return response["data"]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the download link creation process by adding a `user_ip` parameter for improved tracking and logging.
  
- **Bug Fixes**
	- Maintained existing error handling and control flow in related methods, ensuring stability in torrent management functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->