### PR TITLE
Set user ip as a header for premiumize

### DIFF
--- a/streaming_providers/premiumize/client.py
+++ b/streaming_providers/premiumize/client.py
@@ -16,6 +16,10 @@ class Premiumize(DebridClient):
     OAUTH_CLIENT_ID = settings.premiumize_oauth_client_id
     OAUTH_CLIENT_SECRET = settings.premiumize_oauth_client_secret
 
+    def __init__(self, token: Optional[str] = None, user_ip: Optional[str] = None):
+        self.user_ip = user_ip
+        super().__init__(token)
+
     async def _handle_service_specific_errors(self, error_data: dict, status_code: int):
         pass
 
@@ -38,12 +42,15 @@ class Premiumize(DebridClient):
         )
 
     async def initialize_headers(self):
+        self.headers = {}
         if self.token:
             access_token = self.decode_token_str(self.token)
             if access_token:
-                self.headers = {"Authorization": f"Bearer {access_token}"}
+                self.headers["Authorization"] = f"Bearer {access_token}"
             else:
                 self.is_private_token = True
+        if self.user_ip:
+            self.headers['X-Forwarded-For'] = self.user_ip
 
     def get_authorization_url(self) -> str:
         state = uuid4().hex

--- a/streaming_providers/premiumize/utils.py
+++ b/streaming_providers/premiumize/utils.py
@@ -28,13 +28,14 @@ async def get_video_url_from_premiumize(
     info_hash: str,
     magnet_link: str,
     user_data: UserData,
+    user_ip: str,
     filename: Optional[str],
     episode: Optional[int],
     max_retries=5,
     retry_interval=5,
     **kwargs,
 ) -> str:
-    async with Premiumize(token=user_data.streaming_provider.token) as pm_client:
+    async with Premiumize(token=user_data.streaming_provider.token, user_ip=user_ip) as pm_client:
         # Check if the torrent already exists
         torrent_info = await pm_client.get_available_torrent(info_hash)
         if torrent_info:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Premiumize client to accept user IP addresses, improving API interaction.
  - Updated the video URL retrieval function to include user IP for better service personalization.

- **Bug Fixes**
  - Maintained existing error handling and logic in folder ID creation to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->