### PR TITLE
Pass stremio video id to stremthru magnet cache check

### DIFF
--- a/streaming_providers/stremthru/client.py
+++ b/streaming_providers/stremthru/client.py
@@ -117,12 +117,18 @@ class StremThru(DebridClient):
         return response
 
     async def get_torrent_instant_availability(
-        self, magnet_links: list[str], is_http_response: bool = False
+        self,
+        magnet_links: list[str],
+        stremio_video_id: Optional[str] = None,
+        is_http_response: bool = False,
     ):
+        params = {"magnet": ",".join(magnet_links)}
+        if stremio_video_id:
+            params["sid"] = stremio_video_id
         return await self._make_request(
             "GET",
             "/v0/store/magnets/check",
-            params={"magnet": ",".join(magnet_links)},
+            params=params,
             is_http_response=is_http_response,
         )
 

--- a/streaming_providers/stremthru/utils.py
+++ b/streaming_providers/stremthru/utils.py
@@ -69,14 +69,19 @@ async def get_video_url_from_stremthru(
 
 
 async def update_st_cache_status(
-    streams: list[TorrentStreams], user_data: UserData, **kwargs
+    streams: list[TorrentStreams],
+    user_data: UserData,
+    stremio_video_id: str | None,
+    **kwargs,
 ) -> str | None:
     """Updates the cache status of streams based on StremThru's instant availability."""
 
     try:
         async with _get_client(user_data) as st_client:
             res = await st_client.get_torrent_instant_availability(
-                [stream.id for stream in streams], is_http_response=True
+                [stream.id for stream in streams],
+                stremio_video_id=stremio_video_id,
+                is_http_response=True,
             )
             instant_items = res.body.get("data", {}).get("items", [])
             for stream in streams:

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -29,7 +29,10 @@ from utils.validation_helper import validate_m3u8_or_mpd_url_with_cache
 
 
 async def filter_and_sort_streams(
-    streams: list[TorrentStreams], user_data: UserData, user_ip: str | None = None
+    streams: list[TorrentStreams],
+    user_data: UserData,
+    user_ip: str | None = None,
+    stremio_video_id: str | None = None,
 ) -> list[TorrentStreams]:
     # Convert to sets for faster lookups
     selected_resolutions_set = set(user_data.selected_resolutions)
@@ -116,7 +119,10 @@ async def filter_and_sort_streams(
             if cache_update_function:
                 try:
                     service_name = await cache_update_function(
-                        streams=uncached_streams, user_data=user_data, user_ip=user_ip
+                        streams=uncached_streams,
+                        user_data=user_data,
+                        user_ip=user_ip,
+                        stremio_video_id=stremio_video_id,
                     )
                     # Store only the cached ones in Redis
                     cached_info_hashes = [
@@ -221,7 +227,8 @@ async def parse_stream_data(
     if not streams:
         return []
 
-    streams = await filter_and_sort_streams(streams, user_data, user_ip)
+    stremio_video_id = f"{streams[0].meta_id}:{season}:{episode}" if is_series else streams[0].meta_id
+    streams = await filter_and_sort_streams(streams, user_data, user_ip, stremio_video_id)
 
     # Precompute constant values
     show_full_torrent_name = user_data.show_full_torrent_name


### PR DESCRIPTION
StremThru needs the Stremio Video ID to reliably respond with magnet cache info for tv series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced torrent availability checking with optional Stremio video ID support.
	- Improved stream filtering and sorting functionality with Stremio video ID integration.

- **Improvements**
	- Updated cache status update mechanism to utilize Stremio video ID.
	- Added more flexible parameter handling for stream processing.

These changes provide more granular control and enhanced metadata handling for stream and torrent-related operations, potentially improving the overall streaming experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->