### PR TITLE
Add easydebrid add torrent option when its not cached

### DIFF
--- a/streaming_providers/easydebrid/client.py
+++ b/streaming_providers/easydebrid/client.py
@@ -19,6 +19,9 @@ class EasyDebrid(DebridClient):
     async def disable_access_token(self):
         pass
 
+    async def _handle_service_specific_errors(self, error_data: dict, status_code: int):
+        pass
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await super().__aexit__(exc_type, exc_val, exc_tb)
 
@@ -31,6 +34,7 @@ class EasyDebrid(DebridClient):
         params: Optional[dict] = None,
         is_return_none: bool = False,
         is_expected_to_fail: bool = False,
+        is_http_response: bool = False,
         retry_count: int = 0,
     ) -> dict:
         params = params or {}

--- a/streaming_providers/easydebrid/utils.py
+++ b/streaming_providers/easydebrid/utils.py
@@ -22,6 +22,15 @@ async def get_video_url_from_easydebrid(
         user_ip=user_ip,
     ) as easydebrid_client:
         torrent_info = await easydebrid_client.create_download_link(magnet_link)
+        # If create download link returns an error, we try to add the link for caching, the error returned is generally
+        # {'error': 'Unsupported link for direct download.'}
+        if torrent_info.get("error", ""):
+            await easydebrid_client.add_torrent_file(magnet_link)
+            raise ProviderException(
+                "Torrent did not reach downloaded status.",
+                "torrent_not_downloaded.mp4",
+            )
+
         file_index = await select_file_index_from_torrent(
             torrent_info,
             filename,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a fallback mechanism that automatically attempts to process a magnet link if the streaming download link creation initially fails.
  - Added a new method to handle magnet link requests for improved error handling.

- **Bug Fixes**
  - Streamlined the error handling process to prevent unnecessary or misleading error notifications when unsupported links are encountered.

These enhancements improve the system's reliability and overall user experience when handling video streaming downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->