### PR TITLE
Skip invalid seasons or episodes from being stored or being returned to the user

### DIFF
--- a/scrapers/stremio_addons.py
+++ b/scrapers/stremio_addons.py
@@ -102,9 +102,17 @@ class StremioScraper(BaseScraper):
                 stream = self.create_torrent_stream(stream_data, parsed_data, metadata)
 
                 if catalog_type == "series":
-                    if not self.process_series_data(
-                        stream, parsed_data, season, episode, stream_data
-                    ):
+                    episodes = parsed_data.get("episodes")
+
+                    if season not in episodes:
+                        self.metrics.record_skip("Season not found")
+                        return None
+
+                    if episode not in episodes:
+                        self.metrics.record_skip("Episode not found")
+                        return None
+
+                    if not self.process_series_data(stream, parsed_data, season, episode, stream_data):
                         return None
 
                 # Record metrics for successful processing

--- a/scrapers/zilean.py
+++ b/scrapers/zilean.py
@@ -136,10 +136,10 @@ class ZileanScraper(BaseScraper):
 
                 torrent_data = PTT.parse_title(stream["raw_title"], True)
                 if not self.validate_title_and_year(
-                    torrent_data,
-                    metadata,
-                    catalog_type,
-                    stream["raw_title"],
+                        torrent_data,
+                        metadata,
+                        catalog_type,
+                        stream["raw_title"],
                 ):
                     return None
 
@@ -172,21 +172,25 @@ class ZileanScraper(BaseScraper):
                         self.metrics.record_skip("Missing season info")
                         return None
 
-                    if episodes := torrent_data.get("episodes"):
+                    if season not in seasons:
+                        self.metrics.record_skip("Season not found")
+                        return None
+
+                    episodes = torrent_data.get("episodes")
+                    if episodes and episode not in episodes:
+                        self.metrics.record_skip("Episode not found")
+                        return None
+
+                    if episodes:
                         episode_data = [
-                            EpisodeFile(
-                                season_number=seasons[0], episode_number=episode_number
-                            )
-                            for episode_number in episodes
-                        ]
-                    elif seasons:
-                        episode_data = [
-                            EpisodeFile(season_number=season_number, episode_number=1)
-                            for season_number in seasons
+                            EpisodeFile(season_number=seasons[0], episode_number=ep_num)
+                            for ep_num in episodes
                         ]
                     else:
-                        self.metrics.record_skip("Missing episode info")
-                        return None
+                        episode_data = [
+                            EpisodeFile(season_number=season_num, episode_number=1)
+                            for season_num in seasons
+                        ]
 
                     torrent_stream.episode_files = episode_data
 


### PR DESCRIPTION
1. When getting results from parsers, skip if we do not find the right season or episode from being stored in the DB
2. If we have incorrect episodes or seasons stored in the DB, ignore it from being returned to the user. 

I am sure some of the code can be optimized for 1, there are some conditions handled similarly, but taking a first pass to get feedback on this approach before optimizing it. 

https://github.com/mhdzumair/MediaFusion/issues/455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced series streaming selection by introducing refined filtering based on season and episode, ensuring you see only accurately matched content.

- **Bug Fixes**
  - Improved error handling for mismatched series data, reducing the chance of incorrect stream processing and enhancing overall reliability during content discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->