### PR TITLE
feat: detect Polish language for MULTi releases (based on the groups & sites)

### DIFF
--- a/scrapers/bt4g.py
+++ b/scrapers/bt4g.py
@@ -13,6 +13,7 @@ from db.models import TorrentStreams, EpisodeFile, MediaFusionMetaData
 from scrapers.base_scraper import BaseScraper
 from utils.network import CircuitBreaker, batch_process_with_circuit_breaker
 from utils.parser import convert_size_to_bytes, is_contain_18_plus_keywords
+from utils.torrent import _flag_polish_multi
 from utils.runtime_const import BT4G_SEARCH_TTL
 from utils.validation_helper import is_video_file
 
@@ -314,6 +315,7 @@ class BT4GScraper(BaseScraper):
                 return None
 
             parsed_data = PTT.parse_title(torrent_title, True)
+            _flag_polish_multi(torrent_title, parsed_data["languages"])
 
             if not self.validate_title_and_year(
                 parsed_data,
@@ -383,6 +385,7 @@ class BT4GScraper(BaseScraper):
                 ):
                     continue
                 file_parsed_data = PTT.parse_title(file_name)
+                _flag_polish_multi(file_name, file_parsed_data["languages"])
                 seasons.update(file_parsed_data.get("seasons", []))
                 episodes.update(file_parsed_data.get("episodes", []))
                 season_number = (

--- a/utils/polish_sources.py
+++ b/utils/polish_sources.py
@@ -7,7 +7,6 @@ Sources identifying Polish releases.
 
 POLISH_RELEASE_GROUPS: list[str] = [
     "K83",
-    "P2P",
     "BIRD",
     "CHRISVPS",
     "M80",

--- a/utils/polish_sources.py
+++ b/utils/polish_sources.py
@@ -1,0 +1,39 @@
+"""
+Sources identifying Polish releases.
+- POLISH_RELEASE_GROUPS  – release-group tags (UPPERCASE, without spaces).
+- POLISH_SITES_NON_PL    – full hosts of sites whose domain ≠ '.pl'.
+  Use lowercase.
+"""
+
+POLISH_RELEASE_GROUPS: list[str] = [
+    "K83",
+    "P2P",
+    "BIRD",
+    "CHRISVPS",
+    "M80",
+    "DENDA",
+    "MR",
+    "R22",
+    "DSITE",
+    "RALF",
+    "BETON",
+    "KIT",
+    "KOSIARZ66",
+    "DREAM",
+    "LTN",
+    "MG",
+    "B89",
+    "COLO",
+    "KLIO",
+    "FOX",
+    "J60",
+    "LTS",
+    "ALUSIA",
+]
+
+POLISH_SITES_NON_PL: list[str] = [
+    "ex-torrenty.org",
+    "helltorrents.com",
+    "xtorrenty.org",
+    "polskie-torrenty.eu",
+]

--- a/utils/torrent.py
+++ b/utils/torrent.py
@@ -39,7 +39,7 @@ logging.getLogger("demagnetize").setLevel(logging.CRITICAL)
 
 # ─── POLISH-MULTi DETECTOR ────────────────────────────────────
 _MULTI_PL_GROUP_RE = re.compile(
-    rf"(?i)\bMULTI\b.*\b({'|'.join(map(re.escape, POLISH_RELEASE_GROUPS))})\b"
+    rf"(?i)\bMULTI\b.*\b({'|'.join(map(re.escape, POLISH_RELEASE_GROUPS))})(\b|[^A-Za-z])"
 )
 
 _POLISH_SITE_SET = {h.lower() for h in POLISH_SITES_NON_PL}


### PR DESCRIPTION
Hi,

Lately, most of the Polish releases are resistant to PTT because they don't have any PL tag in the title. They just call them MULTi. There are many Polish language releases that can be found on BT4G, but none of them are visible to me in MediaFusion, and I assume it's because they are not tagged as PL.

I came up with this simple logic, for marking a torrent that it has Polish language inside, if the torrent name includes MULTi along with the name of the Polish release group or MULTi along with the well-known Polish name of the torrent site in the torrent title. I've used this approach to manually search for Polish torrents on the BT4G site and always got positive results that the movie has Polish. 

If you can check what the original language of the audio of a movie is, you can modify the logic to check if the original audio is in English, and then safely mark the torrent not only as Polish, but also as English. But checking the native language of the movie is critical here, because if it is, for example, “La casa de papel,” we can't be sure whether the second language after Polish is Spanish or English. We can only be sure it is English if the original is English.

I created a separate file 
`utils/polish_sources.py`.
to easily expand the lists of Polish groups and Polish torrent sites in the future.

I must say here that I am not very experienced in Python, and the code was created with the help of AI. So I apologize in advance if there are any errors or this can be implemented in a better way.

I really hope you will take a look at this and in some form it will find a place in the official code, even if you have to improve the code or implement it in a different, more logical way.

Regards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced detection and automatic tagging of Polish language in torrent metadata for multi-language releases linked to Polish release groups or sites, including those without ".pl" domains.

- **Chores**
  - Added curated lists of Polish release groups and associated torrent sites to improve language identification accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->