### PR TITLE
Update certification mappings

### DIFF
--- a/utils/const.py
+++ b/utils/const.py
@@ -215,59 +215,43 @@ STREAMING_PROVIDERS_SHORT_NAMES = {
 
 CERTIFICATION_MAPPING = {
     "All Ages": [
-        "ATP",
-        "G",
-        "U",
-        "AL/Tous",
-        "Tous Publics",
-        "Public Averti",
-        "All",
-        "AG",
-        "Approved",
-        "0+",
+        "A.G.", "A/fig", "A/i", "A/i/fig", "AA", "Ai", "AL", "AL/Tous", "ALL", 
+        "Alla", "ATP", "Approved", "Btl", "E", "FAM", "G", "General", "Genel İzleyici", 
+        "Genel İzleyici Kitlesi", "KT", "L", "Libre", "Livre", "Públicos", 
+        "Semua", "SU", "T", "TE", "Tous", "Tous Publics", "TP", "U", "UR", "ZA", 
+        "0", "0+", "3", "4+", "5"
     ],
+    
     "Children": [
-        "TV-Y",
-        "TV-G",
-        "C",
-        "6",
-        "7",
-        "7+",
-        "9",
-        "9+",
-        "10",
-        "10+",
-        "11",
-        "12",
-        "12+",
-        "13",
-        "13+",
-        "TV-Y7",
-        "TV-Y7-FV",
-        "TV-PG",
-        "PG",
-        "PG8",
-        "PG-12",
-        "PG-13",
-        "12A",
-        "12PG",
-        "RP13",
-        "R-13",
+        "6", "6+", "6A", "7", "7+", "7-9 PG", "7i", "8", "8+", "9", "9+", 
+        "AP", "Children", "DA", "I", "K", "KN", "LH", "M/4", "M/6", "PG", 
+        "PG8", "TV-G", "TV-Y", "TV-Y7", "TV-Y7-FV", "P"
     ],
-    "Parental Guidance": ["14A", "PG-15", "15A", "15PG", "M", "MA", "RP16", "PG12"],
-    "Teens": ["14", "14+", "15", "15+", "16", "16+", "R-12", "R15", "R16", "TV-14"],
+    
+    "Parental Guidance": [
+        "10", "10+", "10-12 PG", "10A", "11", "12", "12+", "12A", "12PG", "12i", 
+        "B", "BA", "GY", "M/12", "N-7", "P13", "PG-12", "PG12", "Public Averti", 
+        "TV-PG", "VM12"
+    ],
+    
+    "Teens": [
+        "13", "13+", "14", "14+", "14A", "15", "15+", "15A", "15PG", "16", "16+", 
+        "B15", "C", "GA", "I.C.-14", "IIA", "IIB", "M", "M/16", "MA", 
+        "MA 15+", "N-13", "N-16", "NC16", "PG-13", "PG-15", "R", "R-12", "R-13", "R-15+", 
+        "R-16", "RP13", "RP16", "SAM 13", "SAM 16", "TV-14", "VM14", "VM16", "Y"
+    ],
+    
     "Adults": [
-        "A",
-        "18",
-        "18+",
-        "18A",
-        "NC-17",
-        "R",
-        "R18",
-        "R-18",
-        "18TC",
+        "18", "18+", "18A", "18PA", "18PL", "18SG", "18SX", "18TC", "A", 
+        "Caution", "D", "I.M.-18", "III", "M/18", "M18", "N-18", "NC-17", 
+        "R(A)", "R-18", "R18", "RP18", "SAM 18", "TV-MA", "VM18", "Z",
+        "Unrated"
     ],
-    "Adults+": ["R21", "R21+", "21", "21+", "R-21", "R-21+", "R-21A", "XXX", "X"],
+    
+    "Adults+": [
+        "20", "20+", "21", "21+", "Banned", "KK", "R21", "R21+", "R-21", "R-21+", "R-21A", 
+        "RC", "X", "X18", "X 18+", "XX", "XXX"
+    ],
 }
 
 LANGUAGES_FILTERS = [


### PR DESCRIPTION
(Opened as a new branch since I was fiddling with it off and on)

Restructured, with children generally falling in the 1-10 range, PG in 10-13, teens in 13-17, and adults as 17+

Potential issues:
"A" has conflicts. All viewers in Spain. In other regions, it's adult.
"R" is equivalent to PG17 in the US, but is purely adult in Canada/Taiwan.
"C" is recommended for children in Thailand, but PG-15 in Japan (video games only)



### **Moved Certifications**
From "All Ages" to "Parental Guidance"
"Public Averti"

From "Children" to "Parental Guidance"
"10", "10+", "11", "12", "12+", "12A", "12PG", "TV-PG", "PG", "PG-12"

From "Children" to "Teens"
"13", "13+", "C", "PG-13", "RP13", "R-13"

From "Parental Guidance" to "Teens"
"14A", "PG-15", "15A", "15PG", "M", "MA", "RP16"

From "Adults" to "Teens"
"R"

### **New Certifications**
"All Ages" - New
A.G., A/fig, A/i, A/i/fig, AA, Ai, AL, ALL, Alla, Btl, E, FAM, General, Genel İzleyici, Genel İzleyici Kitlesi, KT, L, Libre, Livre, Públicos, Semua, SU, T, TE, TP, UR, ZA, 0, 3, 4+, 5

"Children" - New
6+, 6A, 7-9 PG, 7i, 8, 8+, AP, Children, DA, I, K, KN, LH, M/4, M/6, P

"Parental Guidance" - New
10-12 PG, 10A, 12i, B, BA, GY, M/12, N-7, P13, VM12

"Teens" - New
B15, GA, I.C.-14, IIA, IIB, M/16, MA 15+, N-13, N-16, NC16, R-15+, SAM 13, SAM 16, VM14, VM16, Y

"Adults" - New
18PA, 18PL, 18SG, 18SX, Caution, D, I.M.-18, III, M/18, M18, N-18, R(A), RP18, SAM 18, TV-MA, VM18, Z, Unrated

"Adults+" - New
20, 20+, Banned, KK, RC, X18, X 18+, XX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded and reorganized the list of certification codes to provide broader and more detailed age group categorization.
  - Introduced a new "Adults+" category for more precise adult content ratings.

- **Improvements**
  - Enhanced coverage and accuracy of content certification mapping across all age groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->