### PR TITLE
Follow redirects to fetch and parse schedules from dlhd

### DIFF
--- a/scrapers/dlhd.py
+++ b/scrapers/dlhd.py
@@ -76,6 +76,7 @@ class DLHDScheduleService:
             async with httpx.AsyncClient(proxy=settings.requests_proxy_url) as client:
                 response = await client.get(
                     self.schedule_url,
+                    follow_redirects=True,
                     headers={"Referer": urljoin(self.schedule_url, "/")},
                 )
                 if response.status_code == 200:


### PR DESCRIPTION
Modify `fetch_and_parse_schedule` function to follow redirects and actually grab/parse live events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule fetching reliability by automatically following redirects when accessing the schedule URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->