### PR TITLE
New developer option to use local `scraper_config.json` without having to use the fallback methods indirectly

### DIFF
--- a/db/config.py
+++ b/db/config.py
@@ -118,6 +118,7 @@ class Settings(BaseSettings):
     telegram_chat_id: str | None = None
 
     # Configuration Sources
+    use_config_source: str = "remote"
     remote_config_source: str = (
         "https://raw.githubusercontent.com/mhdzumair/MediaFusion/main/resources/json/scraper_config.json"
     )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,10 @@ Each scheduler has a crontab expression and disable flag:
 
 Each scheduler can be disabled individually using its corresponding `disable_*_scheduler` setting.
 
+## Local Development Settings
+
+- **use_config_source** (default: `remote`): Use the remote scraper configuration file or local source.
+
 ### How to Configure
 
 You can configure these settings either through environment variables in your deployment or through a `.env` file:

--- a/utils/config.py
+++ b/utils/config.py
@@ -44,6 +44,8 @@ class RemoteConfigManager:
 
     def _fetch_config(self) -> Dict[str, Any]:
         """Fetch the configuration from either remote or local source."""
+        if settings.use_config_source == "local":
+            return self._load_local_config(settings.local_config_path)
         if settings.remote_config_source.startswith(("http://", "https://")):
             return self._fetch_remote_config(settings.remote_config_source)
         return self._load_local_config(settings.remote_config_source)


### PR DESCRIPTION
Add developer option to use the local configuration source when building and testing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to choose between using a remote or local configuration source.
  * Users can now specify whether to load the scraper configuration from a remote location or a local file.

* **Documentation**
  * Updated configuration documentation with details about the new option for selecting the configuration source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->