### PR TITLE
[enhance] redis healthcheck

### DIFF
--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     command: redis-server --appendonly yes --save 60 1
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli --raw INFO | grep -q '^loading:0$'"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
redis-cli ping isn't sufficient, in larger instances you'll run into exceptions like `redis.exceptions.BusyLoadingError: Redis is loading the dataset in memory`

this looks for the `loading:1` or `loading:0` in redis-cli INFO as a way to check if redis have finished loading before spinning up mediafusion.

proper way to do this is probably something like on the redis connection wrapper you have, but I didn't dig too deep to understand the code base better to make a pull request.

```
from redis.exceptions import BusyLoadingError
async def wait_redis_ready(r, max_wait=180):
    deadline = asyncio.get_event_loop().time() + max_wait
    while True:
        try:
            if await r.ping():
                # also ensure not loading
                loading = await r.info(section="persistence")
                if int(loading.get("loading", 0)) == 0:
                    return
        except (BusyLoadingError):
            pass
        if asyncio.get_event_loop().time() > deadline:
            raise TimeoutError("Redis not ready within timeout")
        await asyncio.sleep(5)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis service health check to report healthy only after fully loading, enhancing startup reliability for dependent services.
* **Style**
  * Minor formatting cleanup in the compose file with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->