### PR TITLE
avoid log 0 value if size_bytes is zero

### DIFF
--- a/utils/parser.py
+++ b/utils/parser.py
@@ -437,14 +437,14 @@ def convert_bytes_to_readable(size_bytes: int) -> str:
     """
     Convert a size in bytes into a more human-readable format.
     """
-    if size_bytes <= 0:
+    if not size_bytes or size_bytes <= 0:
         return "💾 0 B"
     
     size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
     i = int(math.floor(math.log(size_bytes, 1024)))
     p = math.pow(1024, i)
-    s = size_bytes / p
-    return f"💾 {s:.2g} {size_name[i]}"
+    s = round(size_bytes / p, 2)
+    return f"💾 {s} {size_name[i]}"
 
 
 @functools.lru_cache(maxsize=1024)

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -437,13 +437,14 @@ def convert_bytes_to_readable(size_bytes: int) -> str:
     """
     Convert a size in bytes into a more human-readable format.
     """
-    if not size_bytes:
-        return ""
+    if size_bytes == 0:
+        return "💾 0 B"
+    
     size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
     i = int(math.floor(math.log(size_bytes, 1024)))
     p = math.pow(1024, i)
-    s = round(size_bytes / p, 2)
-    return f"💾 {s} {size_name[i]}"
+    s = size_bytes / p
+    return f"💾 {s:.2g} {size_name[i]}"
 
 
 @functools.lru_cache(maxsize=1024)

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -437,7 +437,7 @@ def convert_bytes_to_readable(size_bytes: int) -> str:
     """
     Convert a size in bytes into a more human-readable format.
     """
-    if size_bytes == 0:
+    if size_bytes <= 0:
         return "💾 0 B"
     
     size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")


### PR DESCRIPTION
Following up on a discussion in an ElfHosted ticket, we've found that certain titles, when returning all results, cause MediaFusion to error 500, with an error log pointing to the convert_bytes_to_readable. 

This PR is an un-educated workaround to this issue as an interim fix - feel free to discard it and do it a better way ;)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zero and negative file sizes now display as “💾 0 B” instead of a blank value, preventing confusing or missing outputs.
* **Chores**
  * Improved edge-case handling for size formatting to ensure stable, predictable display across all inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->