### PR TITLE
Add optional convertkit integration at signup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:developers.kit.com)",
+      "Bash(npx tsc:*)",
+      "Bash(./node_modules/.bin/tsc:*)",
+      "Bash(ls:*)",
+      "Bash(python -c:*)",
+      "Bash(python3:*)"
+    ]
+  }
+}

--- a/api/routers/instance/instance.py
+++ b/api/routers/instance/instance.py
@@ -40,6 +40,7 @@ class InstanceInfo(BaseModel):
     version: str
     logo_url: str
     branding_svg: str | None = None  # Optional partner/host SVG logo URL
+    newsletter: NewsletterConfig
 
 
 class SetupCompleteRequest(BaseModel):
@@ -53,6 +54,14 @@ class SetupCompleteRequest(BaseModel):
     email: EmailStr
     username: str | None = Field(None, min_length=3, max_length=100)
     password: str = Field(..., min_length=8)
+
+
+class NewsletterConfig(BaseModel):
+    """Newsletter opt-in configuration for the frontend."""
+
+    enabled: bool  # Whether newsletter signup is available
+    label: str  # Checkbox label text
+    default_checked: bool  # Whether the checkbox is checked by default
 
 
 class TelegramFeatureConfig(BaseModel):
@@ -109,6 +118,11 @@ async def get_instance_info(
         version=settings.version,
         logo_url=settings.logo_url,
         branding_svg=settings.branding_svg,
+        newsletter=NewsletterConfig(
+            enabled=bool(settings.convertkit_api_key and settings.convertkit_form_id),
+            label=settings.convertkit_newsletter_label,
+            default_checked=settings.convertkit_newsletter_default_checked,
+        ),
     )
 
 

--- a/db/config.py
+++ b/db/config.py
@@ -221,6 +221,14 @@ class Settings(BaseSettings):
     smtp_use_tls: bool = True  # STARTTLS on port 587
     smtp_use_ssl: bool = False  # Implicit SSL on port 465
 
+    # ConvertKit Newsletter Integration (optional)
+    # When convertkit_api_key and convertkit_form_id are both set,
+    # a newsletter opt-in checkbox is shown during registration.
+    convertkit_api_key: str | None = None
+    convertkit_form_id: str | None = None
+    convertkit_newsletter_label: str = "Subscribe to our newsletter"
+    convertkit_newsletter_default_checked: bool = True
+
     # Content Filtering
     adult_content_regex_keywords: str = (
         r"(^|\b|\s|$|[\[._-])"

--- a/frontend/src/contexts/InstanceContext.tsx
+++ b/frontend/src/contexts/InstanceContext.tsx
@@ -8,6 +8,7 @@ import {
   clearStoredApiKey,
   apiClient,
   type InstanceInfo,
+  type NewsletterConfig,
 } from '@/lib/api'
 
 interface InstanceContextType {
@@ -18,6 +19,7 @@ interface InstanceContextType {
   isApiKeyRequired: boolean
   isApiKeySet: boolean
   setupRequired: boolean
+  newsletterConfig: NewsletterConfig
   setApiKey: (key: string) => void
   clearApiKey: () => void
   refetchInstanceInfo: () => Promise<void>
@@ -78,6 +80,10 @@ export function InstanceProvider({ children }: { children: ReactNode }) {
   const isApiKeyRequired = useMemo(() => instanceInfo?.requires_api_key ?? false, [instanceInfo?.requires_api_key])
   const isApiKeySet = useMemo(() => !!apiKey, [apiKey])
   const setupRequired = useMemo(() => instanceInfo?.setup_required ?? false, [instanceInfo?.setup_required])
+  const newsletterConfig = useMemo<NewsletterConfig>(
+    () => instanceInfo?.newsletter ?? { enabled: false, label: '', default_checked: false },
+    [instanceInfo?.newsletter],
+  )
 
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo<InstanceContextType>(
@@ -89,6 +95,7 @@ export function InstanceProvider({ children }: { children: ReactNode }) {
       isApiKeyRequired,
       isApiKeySet,
       setupRequired,
+      newsletterConfig,
       setApiKey: handleSetApiKey,
       clearApiKey: handleClearApiKey,
       refetchInstanceInfo: handleRefetch,
@@ -101,6 +108,7 @@ export function InstanceProvider({ children }: { children: ReactNode }) {
       isApiKeyRequired,
       isApiKeySet,
       setupRequired,
+      newsletterConfig,
       handleSetApiKey,
       handleClearApiKey,
       handleRefetch,

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -9,6 +9,7 @@ export {
   clearStoredApiKey,
   completeSetup,
   type InstanceInfo,
+  type NewsletterConfig,
   type AppConfig,
   type TelegramFeatureConfig,
   type SetupCompleteRequest,

--- a/frontend/src/lib/api/instance.ts
+++ b/frontend/src/lib/api/instance.ts
@@ -8,6 +8,12 @@ const API_BASE_URL = '/api/v1'
 // Local storage key for API key
 const API_KEY_STORAGE_KEY = 'mediafusion_api_key'
 
+export interface NewsletterConfig {
+  enabled: boolean // Whether newsletter signup is available
+  label: string // Checkbox label text
+  default_checked: boolean // Whether the checkbox is checked by default
+}
+
 export interface InstanceInfo {
   is_public: boolean
   requires_api_key: boolean
@@ -16,6 +22,7 @@ export interface InstanceInfo {
   version: string
   logo_url: string
   branding_svg: string | null // Optional partner/host SVG logo URL
+  newsletter: NewsletterConfig
 }
 
 export interface SetupCompleteRequest {

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -10,6 +10,7 @@ import { ThemeSelector } from '@/components/ui/theme-selector'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useAuth } from '@/contexts/AuthContext'
 import { useInstance } from '@/contexts/InstanceContext'
 import { ApiRequestError } from '@/lib/api/client'
@@ -49,7 +50,8 @@ export function RegisterPage() {
   const [apiKeyInput, setApiKeyInput] = useState('')
   const [apiKeyError, setApiKeyError] = useState<string | null>(null)
   const { register: registerUser } = useAuth()
-  const { instanceInfo, isApiKeyRequired, isApiKeySet, setApiKey, clearApiKey, apiKey } = useInstance()
+  const { instanceInfo, isApiKeyRequired, isApiKeySet, setApiKey, clearApiKey, apiKey, newsletterConfig } = useInstance()
+  const [newsletterOptIn, setNewsletterOptIn] = useState(newsletterConfig.default_checked)
   const navigate = useNavigate()
 
   const addonName = instanceInfo?.addon_name || 'MediaFusion'
@@ -96,6 +98,7 @@ export function RegisterPage() {
         email: data.email,
         username: data.username || undefined,
         password: data.password,
+        newsletter_opt_in: newsletterConfig.enabled ? newsletterOptIn : undefined,
       })
 
       // If verification is required, redirect to the verify-email page
@@ -330,6 +333,20 @@ export function RegisterPage() {
                 </div>
                 {errors.confirmPassword && <p className="text-sm text-destructive">{errors.confirmPassword.message}</p>}
               </div>
+
+              {/* Newsletter opt-in */}
+              {newsletterConfig.enabled && (
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="newsletter"
+                    checked={newsletterOptIn}
+                    onCheckedChange={(checked) => setNewsletterOptIn(checked === true)}
+                  />
+                  <Label htmlFor="newsletter" className="text-sm font-normal cursor-pointer">
+                    {newsletterConfig.label}
+                  </Label>
+                </div>
+              )}
             </CardContent>
             <CardFooter className="flex flex-col space-y-4">
               <Button type="submit" variant="gold" className="w-full" disabled={isSubmitting}>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -241,6 +241,7 @@ export interface RegisterRequest {
   email: string
   username?: string
   password: string
+  newsletter_opt_in?: boolean
 }
 
 export interface AuthResponse {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "mediafusion",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
As discussed, here's an AI-assisted PR to implement an optional convertkit opt-in on signup :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added newsletter opt-in functionality to the registration process, allowing users to subscribe during signup.
  * Administrators can now configure newsletter settings and enable ConvertKit integration for newsletter management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->