### PR TITLE
Add optional Zyclops health check proxy for Newznab indexers

### DIFF
--- a/db/schemas/config.py
+++ b/db/schemas/config.py
@@ -361,6 +361,9 @@ class NewznabIndexerConfig(BaseModel):
     # Optional category overrides (use defaults if empty)
     movie_categories: list[int] = Field(default_factory=list, alias="mc")
     tv_categories: list[int] = Field(default_factory=list, alias="tc")
+    # Zyclops health check proxy
+    use_zyclops: bool = Field(default=False, alias="uz")
+    zyclops_backbones: list[str] = Field(default_factory=list, alias="zb")  # backbone slugs
 
     class Config:
         extra = "ignore"

--- a/frontend/src/pages/Configure/components/types.ts
+++ b/frontend/src/pages/Configure/components/types.ts
@@ -62,6 +62,8 @@ export interface NewznabIndexerConfig {
   p?: number // priority
   mc?: number[] // movie_categories
   tc?: number[] // tv_categories
+  uz?: boolean // use_zyclops
+  zb?: string[] // zyclops_backbones (slugs)
 }
 
 export interface StreamingProviderConfigType {

--- a/scrapers/newznab.py
+++ b/scrapers/newznab.py
@@ -224,9 +224,18 @@ class NewznabScraper(BaseScraper):
             UsenetStreamData objects
         """
         # Build URL
-        url = f"{str(indexer.url).rstrip('/')}/api"
         params["apikey"] = indexer.api_key
         params["o"] = "json"  # Request JSON output
+
+        if indexer.use_zyclops:
+            # Proxy through Zyclops health check proxy
+            url = "https://zyclops.elfhosted.com/api"
+            params["target"] = f"{str(indexer.url).rstrip('/')}/api"
+            params["single_ip"] = "true"
+            if indexer.zyclops_backbones:
+                params["backbone"] = ",".join(indexer.zyclops_backbones)
+        else:
+            url = f"{str(indexer.url).rstrip('/')}/api"
 
         try:
             response = await self.http_client.get(url, params=params, timeout=30)


### PR DESCRIPTION
## Summary
- Adds a per-indexer toggle to proxy Newznab queries through [Zyclops](https://zyclops.elfhosted.com) for NZB health filtering
- Users can select backbone(s) matching their usenet provider for provider-specific health status
- Forces `single_ip=true` so Zyclops rewrites download URLs to signed URLs
- Includes a warning that Zyclops sees the indexer URL and API key

## Changes
- **`db/schemas/config.py`** — Added `use_zyclops` (`uz`) and `zyclops_backbones` (`zb`) fields to `NewznabIndexerConfig`
- **`scrapers/newznab.py`** — Proxy logic in `_execute_search()` routes queries through Zyclops when enabled
- **`frontend/.../types.ts`** — TypeScript type additions for new fields
- **`frontend/.../UsenetSettings.tsx`** — Toggle, warning alert, backbone multi-select in IndexerDialog; Zyclops badge on IndexerCard

## Test plan
- [ ] Verify indexers without Zyclops enabled still query upstream directly (unchanged behavior)
- [ ] Enable Zyclops on an indexer and verify queries go to `https://zyclops.elfhosted.com/api?target=<upstream>&single_ip=true`
- [ ] Select backbones and verify `backbone=slug1,slug2` is appended to the proxy request
- [ ] Confirm warning text is displayed when toggling Zyclops on
- [ ] Confirm "Zyclops" badge appears on indexer cards when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zyclops health check capability for Usenet indexers with configurable backbone selection in the settings UI.
  * Indexers can now be configured to route requests through Zyclops proxy with optional backbone filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->