### PR TITLE
Add Stremio NNTP streaming provider for direct NZB playback

### DIFF
--- a/db/schemas/config.py
+++ b/db/schemas/config.py
@@ -149,6 +149,7 @@ class StreamingProvider(BaseModel):
         "nzbget",
         "nzbdav",
         "easynews",
+        "stremio_nntp",
     ] = Field(alias="sv")
     stremthru_store_name: (
         Literal[

--- a/db/schemas/stremio.py
+++ b/db/schemas/stremio.py
@@ -93,6 +93,7 @@ class Stream(BaseModel):
     infoHash: str | None = None
     fileIdx: int | None = None
     url: str | None = None
+    nzbUrl: str | None = None  # Direct NZB URL for Stremio v5 native NNTP streaming
     ytId: str | None = None
     externalUrl: str | None = None
     behaviorHints: StreamBehaviorHints | None = None

--- a/frontend/src/pages/Configure/components/constants.ts
+++ b/frontend/src/pages/Configure/components/constants.ts
@@ -47,6 +47,7 @@ export const STREAMING_PROVIDERS: StreamingProviderOption[] = [
   { value: 'nzbget', label: 'NZBGet + WebDAV', icon: '📰', type: 'Usenet', needsNZBGetConfig: true },
   { value: 'nzbdav', label: 'NzbDAV', icon: '📰', type: 'Usenet', needsNzbDAVConfig: true },
   { value: 'easynews', label: 'Easynews', icon: '📡', type: 'Usenet', needsEasynewsConfig: true },
+  { value: 'stremio_nntp', label: 'Stremio NNTP (v5 Desktop)', icon: '📡', type: 'Usenet' },
 ]
 
 export const STREMTHRU_STORES = [

--- a/streaming_providers/mapper.py
+++ b/streaming_providers/mapper.py
@@ -245,7 +245,7 @@ VALIDATE_CREDENTIALS_FUNCTIONS = {
 # =========================================================================
 
 # Providers that support Usenet content
-USENET_CAPABLE_PROVIDERS = {"torbox", "debrider", "sabnzbd", "nzbget", "nzbdav", "easynews"}
+USENET_CAPABLE_PROVIDERS = {"torbox", "debrider", "sabnzbd", "nzbget", "nzbdav", "easynews", "stremio_nntp"}
 
 # Define provider-specific Usenet cache update functions
 USENET_CACHE_UPDATE_FUNCTIONS = {

--- a/utils/const.py
+++ b/utils/const.py
@@ -180,6 +180,7 @@ STREAMING_SERVICE_REQUIREMENTS = {
     "nzbget": ["nzbget_config"],
     "nzbdav": ["nzbdav_config"],
     "easynews": ["easynews_config"],
+    "stremio_nntp": [],
     "default": ["token"],
 }
 
@@ -237,6 +238,7 @@ STREAMING_PROVIDERS_SHORT_NAMES = {
     "sabnzbd": "SAB",
     "nzbget": "NZB",
     "easynews": "EN",
+    "stremio_nntp": "NNTP",
 }
 
 CERTIFICATION_MAPPING = {

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -615,6 +615,7 @@ def _build_stream_entries(
 
             # Build the stream URL
             stream_url = None
+            nzb_direct_url = None
             info_hash = None
             file_idx = None
             sources = None
@@ -637,7 +638,10 @@ def _build_stream_entries(
             elif is_usenet:
                 # Usenet: use nzb_guid as stream identifier
                 stream_id = stream_data.nzb_guid
-                if has_streaming_provider:
+                if current_provider and current_provider.service == "stremio_nntp":
+                    # Direct NZB streaming — Stremio v5 fetches the NZB and handles NNTP natively
+                    nzb_direct_url = stream_data.nzb_url
+                elif has_streaming_provider:
                     stream_url = base_proxy_url_template.format(stream_id)
                     if episode_data:
                         stream_url += f"/{season}/{episode}"
@@ -729,6 +733,7 @@ def _build_stream_entries(
                 name=stream_name,
                 description=description,
                 url=stream_url,
+                nzbUrl=nzb_direct_url,
                 infoHash=info_hash,
                 fileIdx=file_idx,
                 sources=sources,


### PR DESCRIPTION
## Summary
- Adds a new `stremio_nntp` usenet streaming provider that returns `nzbUrl` directly in the Stremio stream response
- Enables native NNTP streaming in Stremio v5 desktop — no server-side download manager needed
- Zero-config provider (like P2P for torrents): users configure NNTP servers in their Stremio client, not in MediaFusion
- Extends the `Stream` schema with the `nzbUrl` field per the [Stremio addon SDK spec](https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/stream.md)

## Changes
- **`db/schemas/stremio.py`** — Add `nzbUrl` field to `Stream` model
- **`db/schemas/config.py`** — Add `"stremio_nntp"` to `StreamingProvider` service Literal
- **`utils/const.py`** — Add to service requirements (empty, like P2P) and short names (`NNTP`)
- **`streaming_providers/mapper.py`** — Add to `USENET_CAPABLE_PROVIDERS` set
- **`utils/parser.py`** — Handle `stremio_nntp` in usenet stream building: return `nzbUrl` instead of proxy `url`
- **`frontend/.../constants.ts`** — Add "Stremio NNTP (v5 Desktop)" provider option

## How it works
When a user selects `stremio_nntp` as their streaming provider:
1. Usenet streams are included in search results (provider is in `USENET_CAPABLE_PROVIDERS`)
2. Instead of building a proxy URL through MediaFusion's playback endpoint, the stored `nzb_url` from the indexer is returned directly as `nzbUrl` in the stream response
3. Stremio v5 desktop fetches the NZB and handles NNTP download/streaming natively
4. `response_model_exclude_none=True` ensures `nzbUrl` is omitted from responses for all other providers

## Test plan
- [ ] Select "Stremio NNTP (v5 Desktop)" as streaming provider in configure page — no config fields should appear
- [ ] Usenet streams should appear in stream responses with `nzbUrl` field instead of `url`
- [ ] Other usenet providers (SABnzbd, NzbDAV, etc.) continue to use proxy `url` as before
- [ ] Non-usenet streams (torrents, telegram) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Stremio NNTP (v5 Desktop) as a new streaming provider. This Usenet-based option enables direct NZB URL streaming without requiring additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->