### PR TITLE
Add operator-configured NzbDAV defaults for hosted instances

### DIFF
--- a/api/routers/instance/instance.py
+++ b/api/routers/instance/instance.py
@@ -91,6 +91,7 @@ class AppConfig(BaseModel):
     authentication_required: bool
     torznab_enabled: bool
     nzb_file_import_enabled: bool
+    nzbdav_configured: bool  # Whether operator has pre-configured NzbDAV defaults
     telegram: TelegramFeatureConfig
 
 
@@ -154,6 +155,7 @@ async def get_app_config():
         authentication_required=settings.api_password is not None and not settings.is_public_instance,
         torznab_enabled=settings.enable_torznab_api,
         nzb_file_import_enabled=settings.enable_nzb_file_import,
+        nzbdav_configured=bool(settings.default_nzbdav_url and settings.default_nzbdav_api_key),
         telegram=TelegramFeatureConfig(
             enabled=settings.is_scrap_from_telegram,
             bot_configured=bool(settings.telegram_bot_token),

--- a/db/config.py
+++ b/db/config.py
@@ -229,6 +229,13 @@ class Settings(BaseSettings):
     convertkit_newsletter_label: str = "Subscribe to our newsletter"
     convertkit_newsletter_default_checked: bool = False
 
+    # Operator-Configured NzbDAV Defaults
+    # When both are set, all users automatically get NzbDAV as a streaming provider
+    # without needing to configure it manually. Useful for hosted instances with
+    # NzbDAV running as a sidecar service.
+    default_nzbdav_url: str | None = None
+    default_nzbdav_api_key: str | None = None
+
     # Content Filtering
     adult_content_regex_keywords: str = (
         r"(^|\b|\s|$|[\[._-])"

--- a/db/schemas/config.py
+++ b/db/schemas/config.py
@@ -703,12 +703,34 @@ class UserData(BaseModel):
         return "desc"
 
     def get_active_providers(self) -> list[StreamingProvider]:
-        """Get all active streaming providers, sorted by priority."""
+        """Get all active streaming providers, sorted by priority.
+
+        If the operator has configured default NzbDAV settings (via env vars)
+        and the user doesn't already have an NzbDAV provider, a virtual one
+        is injected automatically.
+        """
         providers = []
         if self.streaming_providers:
             providers = [p for p in self.streaming_providers if p.enabled]
         elif self.streaming_provider:
             providers = [self.streaming_provider]
+
+        # Auto-inject operator-configured NzbDAV if user doesn't have one
+        if settings.default_nzbdav_url and settings.default_nzbdav_api_key:
+            has_nzbdav = any(p.service == "nzbdav" for p in providers)
+            if not has_nzbdav:
+                providers.append(
+                    StreamingProvider(
+                        service="nzbdav",
+                        name="operator-nzbdav",
+                        nzbdav_config=NzbDAVConfig(
+                            url=settings.default_nzbdav_url,
+                            api_key=settings.default_nzbdav_api_key,
+                        ),
+                        priority=100,  # Low priority so user providers take precedence
+                    )
+                )
+
         return sorted(providers, key=lambda p: p.priority)
 
     def get_primary_provider(self) -> StreamingProvider | None:

--- a/frontend/src/lib/api/instance.ts
+++ b/frontend/src/lib/api/instance.ts
@@ -55,6 +55,7 @@ export interface AppConfig {
   authentication_required: boolean
   torznab_enabled: boolean
   nzb_file_import_enabled: boolean
+  nzbdav_configured: boolean // Whether operator has pre-configured NzbDAV defaults
   telegram: TelegramFeatureConfig
 }
 

--- a/frontend/src/pages/Configure/components/MultiProviderConfig.tsx
+++ b/frontend/src/pages/Configure/components/MultiProviderConfig.tsx
@@ -1082,14 +1082,18 @@ function SingleProviderEditor({
 export function MultiProviderConfig({ config, onChange }: ConfigSectionProps) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(0)
   const [disabledProviders, setDisabledProviders] = useState<string[]>([])
+  const [nzbdavConfigured, setNzbdavConfigured] = useState(false)
 
-  // Fetch disabled providers from app config
+  // Fetch disabled providers and operator defaults from app config
   useEffect(() => {
     fetch('/api/v1/instance/app-config')
       .then((res) => res.json())
       .then((data) => {
         if (data.disabled_providers) {
           setDisabledProviders(data.disabled_providers)
+        }
+        if (data.nzbdav_configured) {
+          setNzbdavConfigured(true)
         }
       })
       .catch((err) => console.error('Failed to fetch app config:', err))
@@ -1216,6 +1220,16 @@ export function MultiProviderConfig({ config, onChange }: ConfigSectionProps) {
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
+        {nzbdavConfigured && (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              NzbDAV is pre-configured by the instance operator. Usenet streams are automatically available without any
+              additional setup.
+            </AlertDescription>
+          </Alert>
+        )}
+
         {providers.length === 0 ? (
           <Alert>
             <AlertCircle className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Adds `DEFAULT_NZBDAV_URL` and `DEFAULT_NZBDAV_API_KEY` env vars for instance operators
- When both are set, all users automatically get NzbDAV as a streaming provider — no manual configuration needed
- Useful for hosted instances (e.g., ElfHosted) where NzbDAV runs as a sidecar service
- Frontend shows an informational banner when NzbDAV is operator-configured

## How it works
- **Runtime injection**: `UserData.get_active_providers()` auto-appends a virtual NzbDAV provider (priority 100, lowest) when operator defaults are set and the user doesn't already have their own NzbDAV provider
- **No profile mutation**: The injected provider exists only at runtime — nothing is written to user profiles
- **User override**: If a user manually configures their own NzbDAV provider, the operator default is skipped
- **Frontend awareness**: `AppConfig.nzbdav_configured` flag lets the configure page show a notice

## Changes
- **`db/config.py`** — Add `default_nzbdav_url` and `default_nzbdav_api_key` settings
- **`db/schemas/config.py`** — Inject virtual NzbDAV provider in `get_active_providers()`
- **`api/routers/instance/instance.py`** — Add `nzbdav_configured` to `AppConfig`
- **`frontend/src/lib/api/instance.ts`** — Add field to TypeScript interface
- **`frontend/.../MultiProviderConfig.tsx`** — Show operator NzbDAV notice banner

## Test plan
- [ ] Set `DEFAULT_NZBDAV_URL` and `DEFAULT_NZBDAV_API_KEY` env vars and verify usenet streams appear for users without any provider configured
- [ ] Verify users who already have their own NzbDAV provider are unaffected (no duplicate)
- [ ] Verify the frontend shows "NzbDAV is pre-configured by the instance operator" banner
- [ ] Verify without env vars set, behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operators can now pre-configure NzbDAV defaults (URL and API key) for automatic provider setup.
  * System automatically injects a pre-configured NzbDAV provider when operator defaults are established.
  * Users receive an informational alert when NzbDAV is pre-configured, confirming Usenet streams are available without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->