### PR TITLE
Fix for the incorrect ownership of the config file.

### DIFF
--- a/deployment/docker-compose/setup-prowlarr.sh
+++ b/deployment/docker-compose/setup-prowlarr.sh
@@ -33,6 +33,7 @@ docker run --rm -v "$REPO_ROOT/resources/xml/prowlarr-config.xml:/prowlarr-confi
   sed -i 's/\$PROWLARR__POSTGRES_MAIN_DB/'"$PROWLARR__POSTGRES_MAIN_DB"'/g' /config/config.xml;
   sed -i 's/\$PROWLARR__POSTGRES_LOG_DB/'"$PROWLARR__POSTGRES_LOG_DB"'/g' /config/config.xml;
   chmod 664 /config/config.xml;
+  chown 1000:1000 /config/config.xml;
   echo 'Prowlarr config setup complete.';
 "
 


### PR DESCRIPTION
Simple Fix for Prowlarr setup in the docker compose setup. Issue - #593 


Generated config.xml is owned by root, docker expects normal user 'hotio' in this instance.
Opposed to over elevating the perms give ownership to the main docker image user.

Run on ubuntu server and resolves issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker deployment configuration to ensure proper file permissions and ownership within containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->