### PR TITLE
Fix scraper end_date persistence for series metadata

### DIFF
--- a/db/crud/scraper_helpers.py
+++ b/db/crud/scraper_helpers.py
@@ -393,7 +393,7 @@ async def get_or_create_metadata(
         external_id = None
 
     # Determine end_date from end_year if not provided directly
-    end_date = metadata_data.get("end_date")
+    end_date = _normalize_date_value(metadata_data.get("end_date"))
     if not end_date and (end_year := metadata_data.get("end_year")):
         end_date = date(end_year, 12, 31)
 
@@ -558,6 +558,28 @@ def _normalize_year_value(year_value: Any) -> int | None:
         cleaned = year_value.strip()
         if cleaned.isdigit():
             return int(cleaned)
+    return None
+
+
+def _normalize_date_value(date_value: Any) -> date | None:
+    """Normalize mixed date values from scrapers/importers."""
+    if isinstance(date_value, datetime):
+        return date_value.date()
+    if isinstance(date_value, date):
+        return date_value
+    if isinstance(date_value, str):
+        cleaned = date_value.strip()
+        if not cleaned:
+            return None
+        try:
+            return datetime.fromisoformat(cleaned.replace("Z", "+00:00")).date()
+        except ValueError:
+            pass
+        for fmt in ("%Y/%m/%d", "%d-%m-%Y", "%d/%m/%Y"):
+            try:
+                return datetime.strptime(cleaned, fmt).date()
+            except ValueError:
+                continue
     return None
 
 

--- a/db/crud/scraper_helpers.py
+++ b/db/crud/scraper_helpers.py
@@ -394,8 +394,10 @@ async def get_or_create_metadata(
 
     # Determine end_date from end_year if not provided directly
     end_date = _normalize_date_value(metadata_data.get("end_date"))
-    if not end_date and (end_year := metadata_data.get("end_year")):
-        end_date = date(end_year, 12, 31)
+    if not end_date:
+        end_year = _normalize_year_value(metadata_data.get("end_year"))
+        if end_year is not None:
+            end_date = date(end_year, 12, 31)
 
     runtime_minutes = _normalize_runtime_minutes(metadata_data.get("runtime_minutes") or metadata_data.get("runtime"))
 
@@ -941,8 +943,8 @@ async def update_single_imdb_metadata(
 
     # Update end_date for series
     if media_type == "series":
-        end_year = fetched_data.get("end_year")
-        if end_year:
+        end_year = _normalize_year_value(fetched_data.get("end_year"))
+        if end_year is not None:
             media.end_date = date(end_year, 12, 31)
 
         # Update series metadata

--- a/tests/test_media_dedup_guards.py
+++ b/tests/test_media_dedup_guards.py
@@ -1,10 +1,15 @@
+from datetime import date, datetime
 from types import SimpleNamespace
 
 import pytest
 
 from db.crud import scraper_helpers
 from db.crud.catalog import get_catalog_meta_list
-from db.crud.scraper_helpers import _create_external_id_from_metadata, _normalize_year_value
+from db.crud.scraper_helpers import (
+    _create_external_id_from_metadata,
+    _normalize_date_value,
+    _normalize_year_value,
+)
 from db.enums import MediaType
 from db.models.media import Media
 
@@ -23,6 +28,24 @@ def test_normalize_year_value_rejects_invalid_values() -> None:
     assert _normalize_year_value("2015-01-01") is None
     assert _normalize_year_value("abc") is None
     assert _normalize_year_value(None) is None
+
+
+def test_normalize_date_value_accepts_scraper_date_strings() -> None:
+    assert _normalize_date_value("2024-07-19") == date(2024, 7, 19)
+    assert _normalize_date_value("2024-07-19T00:00:00Z") == date(2024, 7, 19)
+
+
+def test_normalize_date_value_accepts_date_objects() -> None:
+    expected = date(2024, 7, 19)
+
+    assert _normalize_date_value(expected) == expected
+    assert _normalize_date_value(datetime(2024, 7, 19, 12, 30)) == expected
+
+
+def test_normalize_date_value_rejects_invalid_values() -> None:
+    assert _normalize_date_value("not-a-date") is None
+    assert _normalize_date_value("") is None
+    assert _normalize_date_value(None) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- normalize scraper-provided end_date values before assigning them to Media.end_date
- preserve the existing end_year fallback when no valid end_date is provided
- add regression coverage for string, date, datetime, and invalid date values

## Context
TMDB series metadata can include end_date as a string, for example Sweet Home (tt11612120) returns end_date='2024-07-19'. Passing that string directly to asyncpg for a DATE column raises: 'str' object has no attribute 'toordinal'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced date handling for scraped metadata with improved parsing of multiple date formats, including ISO-8601 and custom formats
  * Invalid or missing date values gracefully fall back to year-based date generation when available

* **Tests**
  * Added comprehensive test coverage for date validation and normalization functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->