### PR TITLE
fix: case-insensitive IMDB capability check for Prowlarr indexers

### DIFF
--- a/scrapers/base_scraper.py
+++ b/scrapers/base_scraper.py
@@ -1796,7 +1796,8 @@ class IndexerBaseScraper(BaseScraper, abc.ABC):
                 continue
 
             # If we need IMDB support, check if it's available
-            if requires_imdb and "imdbid" not in search_caps[indexer_search_type]:
+            # Prowlarr returns camelCase 'imdbId', so compare case-insensitively
+            if requires_imdb and not any(cap.lower() == "imdbid" for cap in search_caps[indexer_search_type]):
                 continue
 
             # Check if indexer supports any of the required categories


### PR DESCRIPTION
Prowlarr returns search capability parameters in camelCase (e.g. `imdbId`) 
but the filter in `filter_indexers_by_capability` compared against lowercase 
`imdbid`, causing indexers that support IMDB-based tvsearch (e.g. 
TorrentGalaxyClone) to be incorrectly filtered out.

Fix by lowercasing capabilities before comparison so IMDB-capable indexers 
are correctly selected for tvsearch and moviesearch queries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IMDb search reliability by making capability detection case-insensitive, ensuring searches work regardless of indexer configuration casing.
  * Reduces missed or failed IMDb-based results when indexer settings use different capitalization.
  * No changes to overall search behavior, category matching, or other filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->