### PR TITLE
fix: use ubuntu noble runtime to fix aarch64 glibc mismatch

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 COPY --chmod=755 rust-dist/${TARGETARCH}/mediafusion-api /mediafusion-api
 
 # Python builder stage
-FROM python:3.13-slim-noble AS runtime
+FROM python:3.13-slim-noble AS builder
 
 WORKDIR /mediafusion
 
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/mediafusion/.cache/uv \
     uv sync --frozen --no-install-project --compile-bytecode
 
 # Runtime stage
-FROM python:3.13-slim-bookworm AS runtime
+FROM python:3.13-slim-noble AS runtime
 
 WORKDIR /mediafusion
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 COPY --chmod=755 rust-dist/${TARGETARCH}/mediafusion-api /mediafusion-api
 
 # Python builder stage
-FROM python:3.13-slim-bookworm AS builder
+FROM python:3.13-slim-noble AS runtime
 
 WORKDIR /mediafusion
 


### PR DESCRIPTION
**Description:**

## Problem

Since commit 0e750c2 ("perf: cross-compile Rust natively per-arch, eliminate QEMU for Rust builds"), the arm64 Docker image fails to start on aarch64 hosts:

```
/usr/local/bin/mediafusion-api: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
/usr/local/bin/mediafusion-api: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

## Root cause

The arm64 Rust binary is now built on the `ubuntu-24.04-arm` GitHub Actions runner (glibc 2.39). The binary records glibc 2.38/2.39 as a hard minimum requirement. But the Docker runtime stage uses `python:3.13-slim-bookworm` = Debian 12 = glibc 2.36 — too old to satisfy it.

Previously QEMU built the binary inside the container environment, so the glibc versions matched. Native runners are faster, but introduced this mismatch.

This regression only affects `linux/arm64`. amd64 is unaffected.

## Fix

Switch the runtime base to `python:3.13-slim-noble` (Ubuntu 24.04, glibc 2.39) to match the build runner.

## Verified

Confirmed working with a bind-mount workaround that forces the arm64 binary to use the host's Ubuntu 24.04 glibc — the binary starts and runs correctly once glibc 2.39 is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker Python base image to a newer slim variant for build and runtime.
  * Build stage layout and artifact copying remain intact; no duplicate stages introduced.

(Note: previous note about a build configuration issue has been cleared based on this change.)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhdzumair/MediaFusion/pull/672)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->