### PR TITLE
fix(migrate): run migrations on a dedicated connection (advisory-lock leak + statement_timeout)

### DIFF
--- a/backend/src/migrate.rs
+++ b/backend/src/migrate.rs
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use sqlx::{postgres::PgConnection, Connection, PgPool};
+use sqlx::{postgres::PgConnection, ConnectOptions, Connection, PgPool};
 use tracing::{info, warn};
 use url::Url;
 
@@ -115,7 +115,32 @@ pub async fn run(pool: &PgPool) -> Result<(), MigrateError> {
     // returns VersionMissing and the API panics on startup.
     remove_orphaned_migration_rows(pool, &migrator).await?;
 
-    migrator.run(pool).await?;
+    // Run migrations on a dedicated connection rather than borrowing one from
+    // the shared pool. Two reasons, both observed in production:
+    //
+    //  1. statement_timeout: a pool may set a per-session statement_timeout via
+    //     an after_connect hook (e.g. an app-wide query-safety limit). The
+    //     migration advisory-lock acquisition below — and any heavy DDL — would
+    //     then be subject to it and fail with `57014 canceling statement due to
+    //     statement timeout`. Migrations must not inherit the app query timeout.
+    //
+    //  2. advisory-lock leak: sqlx's `Migrator::run` takes a session-level
+    //     `pg_advisory_lock` and, if a migration fails, returns early WITHOUT
+    //     `pg_advisory_unlock`. A *pooled* connection is then returned to the
+    //     pool (not closed) still holding the lock, so every subsequent
+    //     migration attempt (other replicas, restarts) blocks forever on
+    //     `pg_advisory_lock`. A dedicated connection is closed here on both the
+    //     success and failure paths, ending the session and releasing the lock.
+    let mut conn = pool.connect_options().connect().await?;
+    sqlx::query("SET statement_timeout = 0")
+        .execute(&mut conn)
+        .await?;
+    let result = migrator.run(&mut conn).await;
+    // Always close so the session ends and the advisory lock is released, even
+    // when `result` is an error (sqlx skips its own unlock on failure).
+    let _ = conn.close().await;
+    result?;
+
     info!("database migrations complete");
     Ok(())
 }


### PR DESCRIPTION
## Problem

`migrate::run()` finishes with `migrator.run(pool)`, which borrows a connection from the **shared app pool**. This has two failure modes that we hit in production:

### 1. Advisory-lock leak (the serious one)

sqlx's `Migrator::run` takes a session-level `pg_advisory_lock` to serialize migrations, and on success calls `pg_advisory_unlock`. But if **any migration fails**, it returns early via `?` **without unlocking**. Because the connection came from the pool, dropping it **returns it to the pool (it is not closed)** — so the underlying session, and its advisory lock, live on. That connection is then handed back out for normal app queries while still holding the migration lock.

The result: every subsequent migration attempt — other replicas, or this instance after a restart — blocks indefinitely on `SELECT pg_advisory_lock($1)` and eventually dies with:

```
database migration failed: ... canceling statement due to statement timeout (57014)
  at SELECT pg_advisory_lock($1)
```

i.e. a single failed migration wedges **all future startups** until the leaking connection happens to be closed.

### 2. `statement_timeout` applied to migrations

If the pool sets a per-session `statement_timeout` via an `after_connect` hook (a common app-wide query-safety limit), the migration's lock-acquire and any heavy DDL inherit it and fail with the same `57014` — even without contention. Migrations shouldn't be bound by the app's query timeout.

## Fix

Run migrations on a **dedicated connection** (built from `pool.connect_options()`), with `statement_timeout = 0`, and **close it on both the success and failure paths**. Closing ends the session, so the advisory lock is always released — even when sqlx skips its own unlock on failure — and migrations are no longer subject to the pool's per-session timeout.

```rust
let mut conn = pool.connect_options().connect().await?;
sqlx::query("SET statement_timeout = 0").execute(&mut conn).await?;
let result = migrator.run(&mut conn).await;
let _ = conn.close().await; // release the advisory lock on success OR failure
result?;
```

Single-file change to `backend/src/migrate.rs`. `cargo check --bin mediafusion-api` passes; `cargo fmt --check` clean.

## Related observation (not changed here)

`remove_orphaned_migration_rows` deletes `_sqlx_migrations` rows whose version isn't embedded in the running binary. When two binary versions share one database (e.g. a canary/older deploy alongside a newer one), the older binary will delete the newer binary's tracking rows while the committed DDL remains — leaving the newer binary trying to re-apply already-present migrations. Flagging in case it's worth guarding (e.g. only prune below the binary's own max embedded version); happy to follow up in a separate PR if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by ensuring proper resource cleanup and isolation during migration execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->