### PR TITLE
fix(smtp): use starttls_relay() for STARTTLS so port 587 works

### DIFF
--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -1388,7 +1388,10 @@ async fn send_email(
             .port(state.config.smtp_port)
             .tls(Tls::Wrapper(tls))
     } else if state.config.smtp_use_tls {
-        AsyncSmtpTransport::<Tokio1Executor>::relay(smtp_host)?.port(state.config.smtp_port)
+        // STARTTLS: connect plaintext then upgrade. relay() would build an
+        // implicit-TLS (Tls::Wrapper) transport and fail on port 587 with
+        // "received corrupt message of type InvalidContentType".
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(smtp_host)?.port(state.config.smtp_port)
     } else {
         AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(smtp_host)
             .port(state.config.smtp_port)

--- a/backend/src/routes/user_management.rs
+++ b/backend/src/routes/user_management.rs
@@ -661,7 +661,11 @@ async fn send_email(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use lettre::{
         message::header::ContentType,
-        transport::smtp::{authentication::Credentials, AsyncSmtpTransport},
+        transport::smtp::{
+            authentication::Credentials,
+            client::{Tls, TlsParameters},
+            AsyncSmtpTransport,
+        },
         AsyncTransport, Message, Tokio1Executor,
     };
 
@@ -678,8 +682,25 @@ async fn send_email(
         .header(ContentType::TEXT_PLAIN)
         .body(body)?;
 
-    let mut builder =
-        AsyncSmtpTransport::<Tokio1Executor>::relay(smtp_host)?.port(state.config.smtp_port);
+    // SMTP_USE_SSL=true  → implicit TLS wrapper (port 465)
+    // SMTP_USE_TLS=true  → STARTTLS (port 587, default)
+    // both false         → plaintext (internal relay / mailhog)
+    // Port 465 always implies implicit SSL regardless of flags.
+    let use_ssl = state.config.smtp_use_ssl || state.config.smtp_port == 465;
+    let mut builder = if use_ssl {
+        let tls = TlsParameters::new(smtp_host.to_string())?;
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(smtp_host)
+            .port(state.config.smtp_port)
+            .tls(Tls::Wrapper(tls))
+    } else if state.config.smtp_use_tls {
+        // STARTTLS: connect plaintext then upgrade. relay() would build an
+        // implicit-TLS (Tls::Wrapper) transport and fail on port 587 with
+        // "received corrupt message of type InvalidContentType".
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(smtp_host)?.port(state.config.smtp_port)
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(smtp_host)
+            .port(state.config.smtp_port)
+    };
 
     if let (Some(user), Some(pass)) = (
         state.config.smtp_username.as_deref(),


### PR DESCRIPTION
## Problem

Sending email on a STARTTLS submission server (port 587) fails with:

```
send_email_verification failed: Connection error: received corrupt message of type InvalidContentType
```

## Root cause

`send_email()` builds the transport with lettre's `relay()`, which configures **implicit TLS** (`Tls::Wrapper`, port-465 / SMTPS semantics). Overriding `.port(587)` changes only the port — the TLS mode stays implicit. So the client immediately starts a TLS handshake against the server's plaintext `220` SMTP greeting, and rustls parses those bytes as a TLS record → `InvalidContentType`.

Verified against lettre 0.11.22:

| constructor | TLS mode | default port |
|---|---|---|
| `relay()` | `Tls::Wrapper` (implicit) | 465 |
| `starttls_relay()` | `Tls::Required` (STARTTLS) | 587 |

The `SMTP_USE_TLS=true` branch in `auth.rs` is documented as "STARTTLS (port 587)" but calls `relay()`, the opposite mode.

## Fix

- `backend/src/routes/auth.rs` — use `starttls_relay()` for the `SMTP_USE_TLS` path.
- `backend/src/routes/user_management.rs` — this `send_email()` called `relay()` unconditionally with no TLS-mode branching; give it the same `use_ssl` / `use_tls` / plaintext selection as `auth.rs`.

The implicit-SSL path (`SMTP_USE_SSL=true` / port 465) is unchanged and already correct.

## Testing

`cargo check` passes. Validated against Mailgun (`smtp.eu.mailgun.org:587`, STARTTLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email delivery reliability by enhancing support for multiple SMTP server configurations. The system now properly handles implicit TLS encryption, STARTTLS upgrades, and plaintext connections based on your configured email server settings, resolving previous connectivity issues with certain server types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->