### PR TITLE
Fix web UI logout when a content endpoint returns a feature-level 401

### DIFF
--- a/clients/frontend/src/lib/api/client.ts
+++ b/clients/frontend/src/lib/api/client.ts
@@ -205,10 +205,14 @@ class ApiClient {
         if (refreshed) {
           return this.request<T>(endpoint, options, false)
         }
+        // Refresh failed — the session is genuinely gone.
+        this.clearTokens()
+        throw new Error('Session expired. Please log in again.')
       }
 
-      this.clearTokens()
-      throw new Error('Session expired. Please log in again.')
+      // Already retried with a freshly refreshed token and still 401: this is an
+      // endpoint-level authorization failure, not session expiry. Don't log out.
+      throw new ApiRequestError(error.detail || 'An error occurred', response.status, error)
     }
 
     // Handle other non-2xx from proxy or non-API paths
@@ -248,10 +252,15 @@ class ApiClient {
           if (refreshed) {
             return this.request<T>(endpoint, options, false)
           }
+          // Refresh failed — the session is genuinely gone.
+          this.clearTokens()
+          throw new Error('Session expired. Please log in again.')
         }
 
-        this.clearTokens()
-        throw new Error('Session expired. Please log in again.')
+        // Already retried with a freshly refreshed token and the endpoint still
+        // returns a wrapped 401 (e.g. discover/tvdb-filter rejecting a provider
+        // key): this is a feature/provider error, not session expiry. Don't log out.
+        throw new ApiRequestError(data.detail || 'An error occurred', statusCode, data)
       }
 
       throw new ApiRequestError(data.detail || 'An error occurred', statusCode, data)

--- a/clients/frontend/src/lib/api/client.ts
+++ b/clients/frontend/src/lib/api/client.ts
@@ -330,13 +330,26 @@ class ApiClient {
     }
 
     // Handle real HTTP 401 - try to refresh token
-    if (response.status === 401 && retry) {
-      const refreshed = await this.refreshAccessToken()
-      if (refreshed) {
-        return this.upload<T>(endpoint, formData, false)
+    if (response.status === 401) {
+      if (retry) {
+        const refreshed = await this.refreshAccessToken()
+        if (refreshed) {
+          return this.upload<T>(endpoint, formData, false)
+        }
+        // Refresh failed — the session is genuinely gone.
+        this.clearTokens()
+        throw new Error('Session expired. Please log in again.')
       }
-      this.clearTokens()
-      throw new Error('Session expired. Please log in again.')
+
+      // Already retried with a freshly refreshed token and still 401: this is an
+      // endpoint-level authorization failure, not session expiry. Don't log out.
+      let error: ApiError
+      try {
+        error = await response.json()
+      } catch {
+        error = { detail: `HTTP error ${response.status}` }
+      }
+      throw new ApiRequestError(error.detail || 'An error occurred', response.status, error)
     }
 
     if (!response.ok) {
@@ -355,13 +368,18 @@ class ApiClient {
     if (data?.error === true) {
       const statusCode = data.status_code || 500
 
-      if (statusCode === 401 && retry) {
-        const refreshed = await this.refreshAccessToken()
-        if (refreshed) {
-          return this.upload<T>(endpoint, formData, false)
+      if (statusCode === 401) {
+        if (retry) {
+          const refreshed = await this.refreshAccessToken()
+          if (refreshed) {
+            return this.upload<T>(endpoint, formData, false)
+          }
+          // Refresh failed — the session is genuinely gone.
+          this.clearTokens()
+          throw new Error('Session expired. Please log in again.')
         }
-        this.clearTokens()
-        throw new Error('Session expired. Please log in again.')
+        // Persisted after a successful refresh: feature/provider error, not session
+        // expiry. Fall through to the ApiRequestError below (no logout).
       }
 
       throw new ApiRequestError(data.detail || 'An error occurred', statusCode, data)


### PR DESCRIPTION
## What

Stops the web UI from logging the user out when a **content/provider endpoint** returns a 401 that has nothing to do with the session.

Fixes #694.

## Why

`ApiClient.request()` (`clients/frontend/src/lib/api/client.ts`) treated **any** 401 — a real HTTP 401, or a wrapped `200` body `{ error: true, status_code: 401 }` — as session expiry: it tried a token refresh and, if the 401 persisted, called `clearTokens()` → emits `logout`.

That conflates two different things:
- **Session 401** — the access/refresh token is invalid/expired. Logging out is correct.
- **Feature/provider 401** — an endpoint rejects something unrelated to the session. Logging out is wrong.

Repro from #694: with a TVDB v4 key that can *log in* but lacks *filter* access, `GET /api/v1/discover/tvdb-filter` returns `HTTP 200 { error: true, status_code: 401 }`. Opening **Library → Discover** then logs the user out, even though the session is perfectly valid.

## How

Key the logout on **genuine session loss** instead of on the 401 itself:

- Only `clearTokens()` when the **token refresh fails** (no/invalid refresh token).
- If the refresh **succeeds** but the endpoint **still** returns 401 on retry, the session is valid → throw an `ApiRequestError` so the page can handle it gracefully, instead of logging out.

Applied symmetrically to both the real-HTTP-401 branch and the wrapped-200-401 branch. The `api key` / `/auth/login` / `/auth/register` short-circuits are unchanged.

## Effect on the repro

`discover/tvdb-filter` 401 → refresh succeeds (session is fine) → retry still 401 → `ApiRequestError` surfaced to the Discover page (that section degrades), **session untouched, no logout**.

## Testing

- `tsc -b` — clean.
- `eslint src/lib/api/client.ts` — clean.

Frontend-only change. A complementary backend tweak (having `discover_tvdb_filter` surface provider failures with a non-401 wrapped code) would further disambiguate, but is not required for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved handling of HTTP 401 errors by distinguishing true session expiry from authorization failures occurring after a successful retry.
* Tokens are now cleared only when the refresh attempt fails; otherwise, the request returns an authorization-related error instead of forcing a re-login.
* Applied the same behavior to both standard API requests and upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->