### PR TITLE
M3U/IPTV import: make imported channels visible, playable & correctly typed

### DIFF
--- a/backend/migrations/0021_m3u_seed_data.down.sql
+++ b/backend/migrations/0021_m3u_seed_data.down.sql
@@ -1,0 +1,2 @@
+DELETE FROM metadata_provider WHERE name = 'm3u';
+DELETE FROM catalog WHERE name = 'radio';

--- a/backend/migrations/0021_m3u_seed_data.up.sql
+++ b/backend/migrations/0021_m3u_seed_data.up.sql
@@ -1,0 +1,10 @@
+-- Seed the 'm3u' metadata provider used to attribute tvg-logo artwork imported
+-- from M3U playlists, and the 'radio' catalog for audio-only IPTV streams.
+
+INSERT INTO metadata_provider (name, display_name, is_external, is_active, priority, default_priority, created_at)
+VALUES ('m3u', 'M3U', false, true, 0, 0, now())
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO catalog (name, display_name, is_system, display_order)
+VALUES ('radio', 'Radio', true, 0)
+ON CONFLICT (name) DO NOTHING;

--- a/backend/src/jobs/handlers/xtream_import.rs
+++ b/backend/src/jobs/handlers/xtream_import.rs
@@ -406,7 +406,9 @@ impl JobHandler for XtreamImport {
                     let stream_url =
                         format!("{}/live/{}/{}/{}.m3u8", server, user, pass, stream_id);
 
-                    if import_tv_channel(pool, name, &stream_url, logo, &source_label, None).await {
+                    if import_tv_channel(pool, name, &stream_url, logo, None, &source_label, None)
+                        .await
+                    {
                         total_imported += 1;
                     } else {
                         total_skipped += 1;

--- a/backend/src/poster/mod.rs
+++ b/backend/src/poster/mod.rs
@@ -81,49 +81,100 @@ pub fn annotate(
     Ok(buf.into_inner())
 }
 
-/// Generate a placeholder poster (300×450 JPEG) from a title, for media without any
-/// artwork — e.g. M3U/IPTV channels and radios that have no `tvg-logo`. Deterministic:
-/// the same title always yields the same background colour. CPU-bound; wrap in
-/// `tokio::task::spawn_blocking` at the call site.
+/// Generate a placeholder poster (300x450 JPEG) for channels without artwork.
+/// Design: vertical gradient background, channel initials in a circle,
+/// title text below, and the MediaFusion watermark at top-right.
+/// Deterministic: the same title always yields the same colour.
+/// CPU-bound; wrap in `tokio::task::spawn_blocking` at the call site.
 pub fn generate_placeholder(
     title: &str,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     const W: u32 = 300;
     const H: u32 = 450;
 
-    // Deterministic dark background colour from the title (FNV-1a hash → 40..103 per channel).
+    // Deterministic accent colour from the title (FNV-1a hash).
     let mut hash: u32 = 2_166_136_261;
     for byte in title.bytes() {
         hash = (hash ^ byte as u32).wrapping_mul(16_777_619);
     }
-    let bg = Rgba([
-        40 + (hash & 0x3F) as u8,
-        40 + ((hash >> 8) & 0x3F) as u8,
-        40 + ((hash >> 16) & 0x3F) as u8,
-        255,
-    ]);
-    let mut canvas: RgbaImage = RgbaImage::from_pixel(W, H, bg);
+    let r_accent = 60 + (hash & 0x59) as u8; // 60-149
+    let g_accent = 60 + ((hash >> 8) & 0x59) as u8;
+    let b_accent = 80 + ((hash >> 16) & 0x59) as u8; // slightly bluer base
 
-    // Centred, auto-fitted title.
-    let font = bold_font();
-    let display = if title.trim().is_empty() {
-        "Channel"
-    } else {
-        title
-    };
-    let (lines, scale) = fit_title(display, font, W as i32 - 40, 5, 34, 18);
-    let line_h = {
-        let sf = font.as_scaled(scale);
-        (sf.ascent() - sf.descent()) as i32
-    };
-    let mut y = (H as i32 - line_h * lines.len() as i32) / 2;
-    let fill = Rgba([255u8, 255, 255, 255]);
-    let outline = Rgba([0u8, 0, 0, 160]);
-    for line in &lines {
-        let x = (W as i32 - text_width(font, scale, line) as i32) / 2;
-        draw_outlined_text(&mut canvas, x, y, scale, font, line, fill, outline);
-        y += line_h;
+    // Vertical gradient: accent colour at top fading to near-black at bottom.
+    let mut canvas: RgbaImage = RgbaImage::new(W, H);
+    for y in 0..H {
+        let t = y as f32 / H as f32;
+        let blend = 1.0 - t * 0.78;
+        let r = (r_accent as f32 * blend + 15.0 * (1.0 - blend)) as u8;
+        let g = (g_accent as f32 * blend + 15.0 * (1.0 - blend)) as u8;
+        let b = (b_accent as f32 * blend + 20.0 * (1.0 - blend)) as u8;
+        for x in 0..W {
+            canvas.put_pixel(x, y, Rgba([r, g, b, 255]));
+        }
     }
+
+    // Channel initials (up to 2 characters) centred in a translucent circle.
+    let display = if title.trim().is_empty() { "CH" } else { title };
+    let initials: String = display
+        .split_whitespace()
+        .take(2)
+        .filter_map(|w| w.chars().next())
+        .flat_map(|c| c.to_uppercase())
+        .collect();
+
+    let cx = (W / 2) as i32;
+    let cy = (H / 3) as i32;
+    let radius = 52i32;
+
+    // Lighten pixels inside the circle to create a soft "badge".
+    for py in (cy - radius).max(0)..=(cy + radius).min(H as i32 - 1) {
+        for px in (cx - radius).max(0)..=(cx + radius).min(W as i32 - 1) {
+            let dx = px - cx;
+            let dy = py - cy;
+            if dx * dx + dy * dy <= radius * radius {
+                let p = canvas.get_pixel_mut(px as u32, py as u32);
+                p[0] = ((p[0] as u16 * 2 + 255) / 3) as u8;
+                p[1] = ((p[1] as u16 * 2 + 255) / 3) as u8;
+                p[2] = ((p[2] as u16 * 2 + 255) / 3) as u8;
+            }
+        }
+    }
+
+    let font = bold_font();
+    let white = Rgba([255u8, 255, 255, 255]);
+    let shadow = Rgba([0u8, 0, 0, 120]);
+
+    // Initials text centred in the circle.
+    let init_scale = PxScale::from(46.0);
+    let sf_init = font.as_scaled(init_scale);
+    let init_w = text_width(font, init_scale, &initials) as i32;
+    let init_h = (sf_init.ascent() - sf_init.descent()) as i32;
+    draw_outlined_text(
+        &mut canvas,
+        cx - init_w / 2,
+        cy - init_h / 2,
+        init_scale,
+        font,
+        &initials,
+        white,
+        shadow,
+    );
+
+    // Title text below the circle.
+    let title_y = cy + radius + 18;
+    let (lines, title_scale) = fit_title(display, font, W as i32 - 44, 4, 26, 13);
+    let sf_title = font.as_scaled(title_scale);
+    let line_h = (sf_title.ascent() - sf_title.descent()) as i32;
+    let mut y = title_y;
+    for line in &lines {
+        let x = (W as i32 - text_width(font, title_scale, line) as i32) / 2;
+        draw_outlined_text(&mut canvas, x, y, title_scale, font, line, white, shadow);
+        y += line_h + 5;
+    }
+
+    // MediaFusion watermark at top-right (same as the annotate pipeline).
+    add_watermark(&mut canvas);
 
     let rgb = DynamicImage::ImageRgba8(canvas).to_rgb8();
     let mut buf = Cursor::new(Vec::new());

--- a/backend/src/poster/mod.rs
+++ b/backend/src/poster/mod.rs
@@ -106,7 +106,11 @@ pub fn generate_placeholder(
 
     // Centred, auto-fitted title.
     let font = bold_font();
-    let display = if title.trim().is_empty() { "Channel" } else { title };
+    let display = if title.trim().is_empty() {
+        "Channel"
+    } else {
+        title
+    };
     let (lines, scale) = fit_title(display, font, W as i32 - 40, 5, 34, 18);
     let line_h = {
         let sf = font.as_scaled(scale);

--- a/backend/src/poster/mod.rs
+++ b/backend/src/poster/mod.rs
@@ -81,6 +81,52 @@ pub fn annotate(
     Ok(buf.into_inner())
 }
 
+/// Generate a placeholder poster (300×450 JPEG) from a title, for media without any
+/// artwork — e.g. M3U/IPTV channels and radios that have no `tvg-logo`. Deterministic:
+/// the same title always yields the same background colour. CPU-bound; wrap in
+/// `tokio::task::spawn_blocking` at the call site.
+pub fn generate_placeholder(
+    title: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    const W: u32 = 300;
+    const H: u32 = 450;
+
+    // Deterministic dark background colour from the title (FNV-1a hash → 40..103 per channel).
+    let mut hash: u32 = 2_166_136_261;
+    for byte in title.bytes() {
+        hash = (hash ^ byte as u32).wrapping_mul(16_777_619);
+    }
+    let bg = Rgba([
+        40 + (hash & 0x3F) as u8,
+        40 + ((hash >> 8) & 0x3F) as u8,
+        40 + ((hash >> 16) & 0x3F) as u8,
+        255,
+    ]);
+    let mut canvas: RgbaImage = RgbaImage::from_pixel(W, H, bg);
+
+    // Centred, auto-fitted title.
+    let font = bold_font();
+    let display = if title.trim().is_empty() { "Channel" } else { title };
+    let (lines, scale) = fit_title(display, font, W as i32 - 40, 5, 34, 18);
+    let line_h = {
+        let sf = font.as_scaled(scale);
+        (sf.ascent() - sf.descent()) as i32
+    };
+    let mut y = (H as i32 - line_h * lines.len() as i32) / 2;
+    let fill = Rgba([255u8, 255, 255, 255]);
+    let outline = Rgba([0u8, 0, 0, 160]);
+    for line in &lines {
+        let x = (W as i32 - text_width(font, scale, line) as i32) / 2;
+        draw_outlined_text(&mut canvas, x, y, scale, font, line, fill, outline);
+        y += line_h;
+    }
+
+    let rgb = DynamicImage::ImageRgba8(canvas).to_rgb8();
+    let mut buf = Cursor::new(Vec::new());
+    DynamicImage::ImageRgb8(rgb).write_to(&mut buf, image::ImageFormat::Jpeg)?;
+    Ok(buf.into_inner())
+}
+
 // ─── IMDb badge ───────────────────────────────────────────────────────────────
 
 fn add_imdb_badge(canvas: &mut RgbaImage, rating: f32) {

--- a/backend/src/routes/content/iptv_import.rs
+++ b/backend/src/routes/content/iptv_import.rs
@@ -257,6 +257,7 @@ pub async fn import_tv_entry(
         &entry.name,
         &entry.url,
         entry.logo.as_deref(),
+        entry.group.as_deref(),
         source,
         entry.behavior_hints.as_ref(),
     )
@@ -568,7 +569,7 @@ pub async fn run_xtream_import_batch(
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty());
             let url = format!("{server}/live/{username}/{password}/{stream_id}.m3u8");
-            if import_tv_channel(ctx.pool, name, &url, logo, source_name, None).await {
+            if import_tv_channel(ctx.pool, name, &url, logo, None, source_name, None).await {
                 stats.tv += 1;
             } else {
                 stats.skipped += 1;

--- a/backend/src/routes/content/m3u_import.rs
+++ b/backend/src/routes/content/m3u_import.rs
@@ -121,6 +121,10 @@ const SERIES_KEYWORDS: &[&str] = &[
 ];
 const LIVE_STREAM_EXTENSIONS: &[&str] = &[".m3u8", ".ts", ".mpd"];
 const VOD_EXTENSIONS: &[&str] = &[".mp4", ".mkv", ".avi", ".webm", ".mov", ".wmv", ".flv"];
+// Audio-only streams (radio): classified as live "tv" channels — Stremio/MediaFusion
+// have no dedicated radio type, so radio is modelled as a live channel.
+const AUDIO_STREAM_EXTENSIONS: &[&str] =
+    &[".mp3", ".aac", ".m4a", ".ogg", ".opus", ".flac", ".wav", ".audio"];
 
 fn group_contains_keyword(group_lower: &str, keywords: &[&str]) -> bool {
     keywords.iter().any(|kw| group_lower.contains(kw))
@@ -158,6 +162,12 @@ fn detect_content_type_from_url(url: &str) -> Option<&'static str> {
     {
         return Some("tv");
     }
+    if AUDIO_STREAM_EXTENSIONS
+        .iter()
+        .any(|ext| path_lower.ends_with(ext))
+    {
+        return Some("tv");
+    }
     if VOD_EXTENSIONS.iter().any(|ext| path_lower.ends_with(ext)) {
         return None;
     }
@@ -190,28 +200,45 @@ fn detect_content_type(
 ) -> (String, String, Option<i32>, Option<i32>, Option<i32>) {
     let (parsed_title, parsed_year, season, episode) =
         super::iptv_import::parse_iptv_title_info(name);
-    let is_series = season.is_some() || episode.is_some();
 
-    let entry_type = if is_series {
-        "series".to_string()
+    let detected: &str = if let Some(t) = detect_content_type_from_url(url) {
+        // 1. The URL is the strongest signal. A live-stream URL (HLS/DASH/TS,
+        //    audio, or a /live//tv//channel/ path) wins over name parsing because
+        //    live channel names routinely embed numbers ("[5] Canale 5", "Rai 4",
+        //    "Sky Sport 24") that the title parser misreads as an episode number.
+        t
     } else if let Some(t) = detect_content_type_from_group(group_title) {
-        t.to_string()
-    } else if let Some(t) = detect_content_type_from_url(url) {
-        t.to_string()
+        // 2. An explicit group-title keyword from the playlist author.
+        t
+    } else if season.is_some() {
+        // 3. Name-based series detection requires a SEASON marker. A lone episode
+        //    number with no season is almost always a channel number ("[20] 20"),
+        //    not a series episode, so it must NOT force a series classification.
+        "series"
     } else {
+        // 4. No live/series/movie signal: a VOD file extension means a movie;
+        //    otherwise default to a live "tv" channel (relinker / extension-less
+        //    live URLs like RAI's land here) instead of skipping the entry.
         let path_lower = url::Url::parse(url)
             .ok()
             .map(|u| u.path().to_lowercase())
             .unwrap_or_default();
-        let is_vod = VOD_EXTENSIONS.iter().any(|ext| path_lower.ends_with(ext));
-        if is_vod {
-            "movie".to_string()
+        if VOD_EXTENSIONS.iter().any(|ext| path_lower.ends_with(ext)) {
+            "movie"
         } else {
-            "unknown".to_string()
+            "tv"
         }
     };
 
-    (entry_type, parsed_title, parsed_year, season, episode)
+    // Carry season/episode only for a series; otherwise drop the channel-number
+    // artefacts so a live channel isn't tagged with a phantom episode.
+    let (season, episode) = if detected == "series" {
+        (season, episode)
+    } else {
+        (None, None)
+    };
+
+    (detected.to_string(), parsed_title, parsed_year, season, episode)
 }
 
 /// Parse M3U playlist content into a list of entries.
@@ -311,6 +338,38 @@ fn extract_m3u_attr(line: &str, attr: &str) -> Option<String> {
 
 /// Find or create a TV media entry, then insert/link HTTP stream.
 /// Returns true if a new stream was inserted.
+/// True when the stream URL points at an audio-only stream (radio).
+fn url_is_audio_stream(url: &str) -> bool {
+    let path_lower = url::Url::parse(url)
+        .ok()
+        .map(|u| u.path().to_lowercase())
+        .unwrap_or_else(|| url.to_lowercase());
+    AUDIO_STREAM_EXTENSIONS
+        .iter()
+        .any(|ext| path_lower.ends_with(ext))
+}
+
+/// Derive a human-friendly source name from an M3U URL when the user supplies
+/// none. Prefer the playlist filename stem (".../iptvita.m3u" → "M3U - iptvita")
+/// so several playlists from the same host stay distinguishable in IPTV Sources;
+/// fall back to the host, then to a generic label.
+fn derive_source_name_from_url(url: &str) -> String {
+    if let Ok(parsed) = url::Url::parse(url) {
+        let stem = parsed
+            .path_segments()
+            .and_then(|mut segs| segs.rfind(|s| !s.is_empty()))
+            .map(|seg| seg.rsplit_once('.').map(|(s, _)| s).unwrap_or(seg))
+            .filter(|s| !s.is_empty());
+        if let Some(stem) = stem {
+            return format!("M3U - {stem}");
+        }
+        if let Some(host) = parsed.host_str() {
+            return format!("M3U - {host}");
+        }
+    }
+    "M3U Import".to_string()
+}
+
 pub async fn import_tv_channel(
     pool: &sqlx::PgPool,
     name: &str,
@@ -319,8 +378,10 @@ pub async fn import_tv_channel(
     source_name: &str,
     behavior_hints: Option<&serde_json::Value>,
 ) -> bool {
-    // Find existing media by title+type
-    let media_id: Option<i64> = sqlx::query_scalar(
+    // Find existing media by title+type. media.id is INT4 (i32) — reading it as i64
+    // makes the sqlx decode fail (→ None), so the lookup/insert silently never
+    // resolves an id and the whole import is skipped. Must be i32.
+    let media_id: Option<i32> = sqlx::query_scalar(
         "SELECT id FROM media WHERE LOWER(title) = LOWER($1) AND type = $2 LIMIT 1",
     )
     .bind(name)
@@ -334,7 +395,7 @@ pub async fn import_tv_channel(
         Some(id) => id,
         None => {
             // Insert new media
-            let res: Option<(i64,)> = sqlx::query_as(
+            let res: Option<(i32,)> = sqlx::query_as(
                 "INSERT INTO media (title, type, created_at, adult, is_blocked, is_public, is_user_created, nudity_status, total_streams, popularity) \
                  VALUES ($1, $2, NOW(), false, false, true, false, 'UNKNOWN', 0, 0.0) \
                  ON CONFLICT DO NOTHING RETURNING id",
@@ -350,7 +411,7 @@ pub async fn import_tv_channel(
                 Some((id,)) => id,
                 None => {
                     // Conflict: fetch existing
-                    match sqlx::query_scalar::<_, i64>(
+                    match sqlx::query_scalar::<_, i32>(
                         "SELECT id FROM media WHERE LOWER(title) = LOWER($1) AND type = $2 LIMIT 1",
                     )
                     .bind(name)
@@ -368,15 +429,70 @@ pub async fn import_tv_channel(
         }
     };
 
-    // Update poster if logo is provided and media has no poster
-    if let Some(poster) = logo {
-        let _ = sqlx::query(
-            "UPDATE media SET poster = $1 WHERE id = $2 AND (poster IS NULL OR poster = '')",
+    // Link the channel to its catalog so it isn't orphaned (no catalog → invisible
+    // in Library Browse and the Stremio catalog). Audio-only streams (radio) go to a
+    // dedicated "Radio" catalog; everything else to "Live TV". Both idempotent.
+    let is_radio = url_is_audio_stream(url) || name.to_lowercase().contains("radio");
+    let (catalog_name, catalog_display) = if is_radio {
+        ("radio", "Radio")
+    } else {
+        ("live_tv", "Live TV")
+    };
+    let _ = sqlx::query(
+        "INSERT INTO catalog (name, display_name, is_system, display_order) \
+         VALUES ($1, $2, true, 0) ON CONFLICT (name) DO NOTHING",
+    )
+    .bind(catalog_name)
+    .bind(catalog_display)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query(
+        "INSERT INTO media_catalog_link (media_id, catalog_id) \
+         SELECT $1, c.id FROM catalog c WHERE c.name = $2 ON CONFLICT DO NOTHING",
+    )
+    .bind(media_id)
+    .bind(catalog_name)
+    .execute(pool)
+    .await;
+
+    // Persist the channel logo (tvg-logo) as a poster image. Posters live in
+    // `media_image` (the only table the /poster handler reads) — there is NO
+    // `media.poster` column, so the previous UPDATE silently errored and every
+    // channel fell back to a generated placeholder. Attribute the artwork to a
+    // dedicated "m3u" metadata provider (get-or-create), and de-dup on the
+    // table's unique key so re-imports are idempotent.
+    if let Some(logo_url) = logo.filter(|l| !l.is_empty()) {
+        let provider_id: Option<i32> = sqlx::query_scalar(
+            r#"WITH ins AS (
+                   INSERT INTO metadata_provider
+                       (name, display_name, is_external, is_active, priority, default_priority, created_at)
+                   VALUES ('m3u', 'M3U', false, true, 0, 0, NOW())
+                   ON CONFLICT (name) DO NOTHING
+                   RETURNING id
+               )
+               SELECT id FROM ins
+               UNION ALL
+               SELECT id FROM metadata_provider WHERE name = 'm3u'
+               LIMIT 1"#,
         )
-        .bind(poster)
-        .bind(media_id)
-        .execute(pool)
-        .await;
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+
+        if let Some(pid) = provider_id {
+            let _ = sqlx::query(
+                "INSERT INTO media_image \
+                    (media_id, provider_id, image_type, url, is_primary, display_order) \
+                 VALUES ($1, $2, 'poster', $3, true, 0) \
+                 ON CONFLICT (media_id, provider_id, image_type, url) DO NOTHING",
+            )
+            .bind(media_id)
+            .bind(pid)
+            .bind(logo_url)
+            .execute(pool)
+            .await;
+        }
     }
 
     // Check for existing stream with this URL linked to this media
@@ -387,7 +503,7 @@ pub async fn import_tv_channel(
          LIMIT 1",
     )
     .bind(url)
-    .bind(media_id as i32)
+    .bind(media_id)
     .fetch_optional(pool)
     .await
     .ok()
@@ -413,7 +529,7 @@ pub async fn import_tv_channel(
     };
 
     let opts = crate::db::StoreStreamOpts::user_import(
-        crate::db::MediaId(media_id as i32),
+        crate::db::MediaId(media_id),
         crate::db::MediaType::Movie,
     );
 
@@ -841,10 +957,7 @@ pub async fn import_m3u(
             if save_source_bg {
                 if let Some(ref url) = m3u_url_bg {
                     let save_name = if source_name_bg.is_empty() {
-                        url::Url::parse(url)
-                            .ok()
-                            .and_then(|u| u.host_str().map(|h| format!("M3U - {h}")))
-                            .unwrap_or_else(|| "M3U Import".to_string())
+                        derive_source_name_from_url(url)
                     } else {
                         source_name_bg.clone()
                     };
@@ -920,12 +1033,7 @@ pub async fn import_m3u(
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .map(str::to_string)
-                .unwrap_or_else(|| {
-                    url::Url::parse(url)
-                        .ok()
-                        .and_then(|u| u.host_str().map(|h| format!("M3U - {h}")))
-                        .unwrap_or_else(|| "M3U Import".to_string())
-                });
+                .unwrap_or_else(|| derive_source_name_from_url(url));
             source_id = super::iptv_import::save_m3u_iptv_source(
                 &state.pool,
                 user_id,
@@ -1005,4 +1113,61 @@ pub async fn get_iptv_settings_handler(State(state): State<Arc<AppState>>) -> Re
         "allow_public_sharing": state.config.allow_public_iptv_sharing,
     }))
     .into_response()
+}
+
+#[cfg(test)]
+mod detection_tests {
+    use super::detect_content_type;
+
+    fn type_of(name: &str, url: &str, group: Option<&str>) -> String {
+        detect_content_type(name, url, group).0
+    }
+
+    #[test]
+    fn live_channels_with_number_prefix_are_tv_not_series() {
+        // Regression: the "[N]" channel-number prefix was parsed as an episode
+        // number, flagging every live channel as a series (Tundrak/IPTV-Italia).
+        let mpd = "https://cdn.example.net/live/ch-c5/c5-clr.isml/manifest.mpd";
+        let hls = "https://cdn.example.net/v1/master/abc/Live.m3u8";
+        assert_eq!(type_of("[5] Canale 5", mpd, None), "tv");
+        assert_eq!(type_of("[7] LA7", hls, None), "tv");
+        assert_eq!(type_of("[20] 20", mpd, None), "tv");
+    }
+
+    #[test]
+    fn extensionless_relinker_live_url_defaults_to_tv() {
+        // RAI relinker URLs have no file extension and no /live/ path; with a bare
+        // channel number in the name they must still resolve to a live tv channel.
+        let relinker =
+            "http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803&output=7";
+        assert_eq!(type_of("[1] Rai 1", relinker, None), "tv");
+        assert_eq!(type_of("[24] Rai Movie", relinker, None), "tv");
+    }
+
+    #[test]
+    fn real_series_with_season_marker_is_series() {
+        // A genuine SxxExx VOD entry keeps its series classification.
+        let mp4 = "https://vod.example.net/series/show/s01e02.mp4";
+        assert_eq!(type_of("Breaking Bad S01E02", mp4, None), "series");
+    }
+
+    #[test]
+    fn vod_movie_extension_is_movie() {
+        let mp4 = "https://vod.example.net/movies/inception.mp4";
+        assert_eq!(type_of("Inception 2010", mp4, None), "movie");
+    }
+
+    #[test]
+    fn audio_stream_is_tv() {
+        // Radio: audio-extension URLs classify as tv (routed to the Radio catalog
+        // downstream by import_tv_channel).
+        let mp3 = "https://radio.example.net/stream/radio1.mp3";
+        assert_eq!(type_of("[1] Radio Uno", mp3, None), "tv");
+    }
+
+    #[test]
+    fn group_title_movie_keyword_wins_when_url_is_ambiguous() {
+        let ambiguous = "http://host.example.net/path/12345";
+        assert_eq!(type_of("Some Title", ambiguous, Some("VOD Movies")), "movie");
+    }
 }

--- a/backend/src/routes/content/m3u_import.rs
+++ b/backend/src/routes/content/m3u_import.rs
@@ -123,8 +123,9 @@ const LIVE_STREAM_EXTENSIONS: &[&str] = &[".m3u8", ".ts", ".mpd"];
 const VOD_EXTENSIONS: &[&str] = &[".mp4", ".mkv", ".avi", ".webm", ".mov", ".wmv", ".flv"];
 // Audio-only streams (radio): classified as live "tv" channels — Stremio/MediaFusion
 // have no dedicated radio type, so radio is modelled as a live channel.
-const AUDIO_STREAM_EXTENSIONS: &[&str] =
-    &[".mp3", ".aac", ".m4a", ".ogg", ".opus", ".flac", ".wav", ".audio"];
+const AUDIO_STREAM_EXTENSIONS: &[&str] = &[
+    ".mp3", ".aac", ".m4a", ".ogg", ".opus", ".flac", ".wav", ".audio",
+];
 
 fn group_contains_keyword(group_lower: &str, keywords: &[&str]) -> bool {
     keywords.iter().any(|kw| group_lower.contains(kw))
@@ -238,7 +239,13 @@ fn detect_content_type(
         (None, None)
     };
 
-    (detected.to_string(), parsed_title, parsed_year, season, episode)
+    (
+        detected.to_string(),
+        parsed_title,
+        parsed_year,
+        season,
+        episode,
+    )
 }
 
 /// Parse M3U playlist content into a list of entries.
@@ -1168,6 +1175,9 @@ mod detection_tests {
     #[test]
     fn group_title_movie_keyword_wins_when_url_is_ambiguous() {
         let ambiguous = "http://host.example.net/path/12345";
-        assert_eq!(type_of("Some Title", ambiguous, Some("VOD Movies")), "movie");
+        assert_eq!(
+            type_of("Some Title", ambiguous, Some("VOD Movies")),
+            "movie"
+        );
     }
 }

--- a/backend/src/routes/content/m3u_import.rs
+++ b/backend/src/routes/content/m3u_import.rs
@@ -343,9 +343,6 @@ fn extract_m3u_attr(line: &str, attr: &str) -> Option<String> {
 
 // ─── DB helpers for TV channel insertion ──────────────────────────────────────
 
-/// Find or create a TV media entry, then insert/link HTTP stream.
-/// Returns true if a new stream was inserted.
-/// True when the stream URL points at an audio-only stream (radio).
 fn url_is_audio_stream(url: &str) -> bool {
     let path_lower = url::Url::parse(url)
         .ok()
@@ -382,6 +379,7 @@ pub async fn import_tv_channel(
     name: &str,
     url: &str,
     logo: Option<&str>,
+    group: Option<&str>,
     source_name: &str,
     behavior_hints: Option<&serde_json::Value>,
 ) -> bool {
@@ -436,56 +434,25 @@ pub async fn import_tv_channel(
         }
     };
 
-    // Link the channel to its catalog so it isn't orphaned (no catalog → invisible
-    // in Library Browse and the Stremio catalog). Audio-only streams (radio) go to a
-    // dedicated "Radio" catalog; everything else to "Live TV". Both idempotent.
-    let is_radio = url_is_audio_stream(url) || name.to_lowercase().contains("radio");
-    let (catalog_name, catalog_display) = if is_radio {
-        ("radio", "Radio")
-    } else {
-        ("live_tv", "Live TV")
-    };
-    let _ = sqlx::query(
-        "INSERT INTO catalog (name, display_name, is_system, display_order) \
-         VALUES ($1, $2, true, 0) ON CONFLICT (name) DO NOTHING",
-    )
-    .bind(catalog_name)
-    .bind(catalog_display)
-    .execute(pool)
-    .await;
-    let _ = sqlx::query(
-        "INSERT INTO media_catalog_link (media_id, catalog_id) \
-         SELECT $1, c.id FROM catalog c WHERE c.name = $2 ON CONFLICT DO NOTHING",
-    )
-    .bind(media_id)
-    .bind(catalog_name)
-    .execute(pool)
-    .await;
+    // Link the channel to its catalog. Audio-only streams (radio) go to the
+    // "radio" catalog; everything else to "live_tv". Both are seeded by migration.
+    // Use the group title as the primary radio signal; fall back to URL extension.
+    let group_lower = group.map(|g| g.to_lowercase()).unwrap_or_default();
+    let is_radio =
+        group_lower.contains("radio") || group_lower.contains("audio") || url_is_audio_stream(url);
+    let catalog_name = if is_radio { "radio" } else { "live_tv" };
+    crate::db::link_to_catalogs(pool, media_id, &[catalog_name]).await;
 
     // Persist the channel logo (tvg-logo) as a poster image. Posters live in
     // `media_image` (the only table the /poster handler reads) — there is NO
-    // `media.poster` column, so the previous UPDATE silently errored and every
-    // channel fell back to a generated placeholder. Attribute the artwork to a
-    // dedicated "m3u" metadata provider (get-or-create), and de-dup on the
-    // table's unique key so re-imports are idempotent.
+    // `media.poster` column. The 'm3u' provider is seeded by migration 0021.
     if let Some(logo_url) = logo.filter(|l| !l.is_empty()) {
-        let provider_id: Option<i32> = sqlx::query_scalar(
-            r#"WITH ins AS (
-                   INSERT INTO metadata_provider
-                       (name, display_name, is_external, is_active, priority, default_priority, created_at)
-                   VALUES ('m3u', 'M3U', false, true, 0, 0, NOW())
-                   ON CONFLICT (name) DO NOTHING
-                   RETURNING id
-               )
-               SELECT id FROM ins
-               UNION ALL
-               SELECT id FROM metadata_provider WHERE name = 'm3u'
-               LIMIT 1"#,
-        )
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten();
+        let provider_id: Option<i32> =
+            sqlx::query_scalar("SELECT id FROM metadata_provider WHERE name = 'm3u' LIMIT 1")
+                .fetch_optional(pool)
+                .await
+                .ok()
+                .flatten();
 
         if let Some(pid) = provider_id {
             let _ = sqlx::query(

--- a/backend/src/routes/poster.rs
+++ b/backend/src/routes/poster.rs
@@ -48,7 +48,8 @@ pub async fn handler(
         if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
             let title = title.to_string();
             if let Ok(Ok(bytes)) =
-                tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title)).await
+                tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title))
+                    .await
             {
                 cache::set_bytes(&state.redis, &cache_key, &bytes, 86400).await;
                 return jpeg_response(bytes);

--- a/backend/src/routes/poster.rs
+++ b/backend/src/routes/poster.rs
@@ -43,16 +43,19 @@ pub async fn handler(
             return fetch_annotate_cache(&state, &cache_key, &url, meta).await;
         }
 
-        // No artwork (M3U/IPTV channels & radios without a tvg-logo): generate a
-        // name-based placeholder poster instead of returning 404.
-        if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
-            let title = title.to_string();
-            if let Ok(Ok(bytes)) =
-                tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title))
-                    .await
-            {
-                cache::set_bytes(&state.redis, &cache_key, &bytes, 86400).await;
-                return jpeg_response(bytes);
+        // No artwork: generate a name-based placeholder only for live TV channels
+        // (type = "tv"). Movies and series without posters are awaiting scraping —
+        // generating a placeholder for them would mask missing artwork.
+        if media_type == "tv" {
+            if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
+                let title = title.to_string();
+                if let Ok(Ok(bytes)) =
+                    tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title))
+                        .await
+                {
+                    cache::set_bytes(&state.redis, &cache_key, &bytes, 86400).await;
+                    return jpeg_response(bytes);
+                }
             }
         }
     }

--- a/backend/src/routes/poster.rs
+++ b/backend/src/routes/poster.rs
@@ -39,12 +39,26 @@ pub async fn handler(
             _ => None,
         };
 
+        // Try to fetch and annotate the poster URL if one exists. Returns None
+        // on any upstream error (404, unreachable, bad image format) so we can
+        // fall through to the placeholder below.
         if let Some(url) = poster_url {
-            return fetch_annotate_cache(&state, &cache_key, &url, meta).await;
+            if let Some(bytes) = fetch_annotate_cache(
+                &state,
+                &cache_key,
+                &url,
+                meta.imdb_rating,
+                meta.is_add_title,
+                meta.title.as_deref(),
+            )
+            .await
+            {
+                return jpeg_response(bytes);
+            }
         }
 
-        // No artwork: generate a name-based placeholder so the user always sees
-        // something instead of a broken image, regardless of media type.
+        // No artwork, or upstream fetch failed: generate a name-based placeholder
+        // so the user always sees something instead of a broken image.
         if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
             let title = title.to_string();
             if let Ok(Ok(bytes)) =
@@ -89,13 +103,19 @@ async fn serve_event_poster(state: &AppState, event_id: &str, cache_key: &str) -
         return StatusCode::NOT_FOUND.into_response();
     };
 
-    let meta = PosterMeta {
-        poster_url: Some(url.clone()),
+    if let Some(bytes) = fetch_annotate_cache(
+        state,
+        cache_key,
+        &url,
         imdb_rating,
-        title,
         is_add_title,
-    };
-    fetch_annotate_cache(state, cache_key, &url, meta).await
+        title.as_deref(),
+    )
+    .await
+    {
+        return jpeg_response(bytes);
+    }
+    StatusCode::NOT_FOUND.into_response()
 }
 
 // ─── DB resolution ────────────────────────────────────────────────────────────
@@ -242,12 +262,16 @@ async fn resolve_sports_poster_strict(state: &AppState, id: &str) -> Option<Stri
 
 // ─── Fetch + annotate + cache ─────────────────────────────────────────────────
 
+/// Fetch a poster URL, annotate it, cache the result, and return the bytes.
+/// Returns `None` on any upstream failure so callers can fall back to a placeholder.
 async fn fetch_annotate_cache(
     state: &AppState,
     cache_key: &str,
     url: &str,
-    meta: PosterMeta,
-) -> Response {
+    imdb_rating: Option<f32>,
+    is_add_title: bool,
+    title: Option<&str>,
+) -> Option<Vec<u8>> {
     let resp = state
         .http
         .get(url)
@@ -260,30 +284,26 @@ async fn fetch_annotate_cache(
             Ok(b) => b,
             Err(e) => {
                 warn!("poster fetch bytes {url}: {e}");
-                return StatusCode::BAD_GATEWAY.into_response();
+                return None;
             }
         },
         Ok(r) => {
-            // Downgrade to debug: upstream 404/non-2xx for external image hosts is common
-            // and expected (missing posters). Not a backend bug.
             debug!("poster upstream {url}: HTTP {}", r.status());
-            return StatusCode::NOT_FOUND.into_response();
+            return None;
         }
         Err(e) => {
-            // Downgrade to debug: third-party image hosts being unreachable is expected
-            // noise and not actionable from the backend. Response is still 502 to the client.
             debug!(
                 error_kind = http::transport_error_kind(&e),
                 "poster fetch {url}: {e}"
             );
-            return StatusCode::BAD_GATEWAY.into_response();
+            return None;
         }
     };
 
     let params = AnnotateParams {
-        imdb_rating: meta.imdb_rating,
-        title: meta.title,
-        is_add_title: meta.is_add_title,
+        imdb_rating,
+        title: title.map(str::to_string),
+        is_add_title,
     };
     let raw_bytes_clone = raw_bytes.to_vec();
     let annotated =
@@ -293,8 +313,6 @@ async fn fetch_annotate_cache(
     let final_bytes: Vec<u8> = match annotated {
         Ok(Ok(b)) => b,
         Ok(Err(e)) => {
-            // Downgrade to debug: image-format failures from external hosts are expected
-            // (WebP/AVIF/truncated), the code already falls back to the raw image gracefully.
             debug!("poster annotate failed ({e}), serving unannotated");
             raw_bytes.to_vec()
         }
@@ -305,7 +323,7 @@ async fn fetch_annotate_cache(
     };
 
     cache::set_bytes(&state.redis, cache_key, &final_bytes, 86400).await;
-    jpeg_response(final_bytes)
+    Some(final_bytes)
 }
 
 fn jpeg_response(bytes: Vec<u8>) -> Response {

--- a/backend/src/routes/poster.rs
+++ b/backend/src/routes/poster.rs
@@ -43,19 +43,16 @@ pub async fn handler(
             return fetch_annotate_cache(&state, &cache_key, &url, meta).await;
         }
 
-        // No artwork: generate a name-based placeholder only for live TV channels
-        // (type = "tv"). Movies and series without posters are awaiting scraping —
-        // generating a placeholder for them would mask missing artwork.
-        if media_type == "tv" {
-            if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
-                let title = title.to_string();
-                if let Ok(Ok(bytes)) =
-                    tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title))
-                        .await
-                {
-                    cache::set_bytes(&state.redis, &cache_key, &bytes, 86400).await;
-                    return jpeg_response(bytes);
-                }
+        // No artwork: generate a name-based placeholder so the user always sees
+        // something instead of a broken image, regardless of media type.
+        if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
+            let title = title.to_string();
+            if let Ok(Ok(bytes)) =
+                tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title))
+                    .await
+            {
+                cache::set_bytes(&state.redis, &cache_key, &bytes, 86400).await;
+                return jpeg_response(bytes);
             }
         }
     }

--- a/backend/src/routes/poster.rs
+++ b/backend/src/routes/poster.rs
@@ -42,6 +42,18 @@ pub async fn handler(
         if let Some(url) = poster_url {
             return fetch_annotate_cache(&state, &cache_key, &url, meta).await;
         }
+
+        // No artwork (M3U/IPTV channels & radios without a tvg-logo): generate a
+        // name-based placeholder poster instead of returning 404.
+        if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty()) {
+            let title = title.to_string();
+            if let Ok(Ok(bytes)) =
+                tokio::task::spawn_blocking(move || crate::poster::generate_placeholder(&title)).await
+            {
+                cache::set_bytes(&state.redis, &cache_key, &bytes, 86400).await;
+                return jpeg_response(bytes);
+            }
+        }
     }
 
     StatusCode::NOT_FOUND.into_response()

--- a/clients/frontend/src/pages/Configure/components/constants.ts
+++ b/clients/frontend/src/pages/Configure/components/constants.ts
@@ -111,6 +111,7 @@ export const CATALOGS = {
   ],
   'Live & Sports': [
     { id: 'live_tv', name: 'Live TV' },
+    { id: 'radio', name: 'Radio' },
     { id: 'live_sport_events', name: 'Live Sport Events' },
     { id: 'football', name: 'Football' },
     { id: 'basketball', name: 'Basketball' },

--- a/clients/frontend/src/pages/ContentImport/components/M3UTab.tsx
+++ b/clients/frontend/src/pages/ContentImport/components/M3UTab.tsx
@@ -128,6 +128,9 @@ export function M3UTab({ onSuccess, onError, iptvSettings }: M3UTabProps) {
     try {
       const result = await importM3U.mutateAsync({
         redis_key: analysis.redis_key,
+        // Resend the URL so the backend can persist the IPTV source on import
+        // (save_source only saves when m3u_url is present).
+        m3u_url: m3uUrl || undefined,
         is_public: isPublic,
         overrides: overrideList.length > 0 ? overrideList : undefined,
         save_source: saveSource,
@@ -387,7 +390,10 @@ export function M3UTab({ onSuccess, onError, iptvSettings }: M3UTabProps) {
                     <div className="flex items-center justify-between p-3 rounded-xl bg-muted/30 border border-border/50">
                       <div className="flex items-center gap-2">
                         <FileInput className="h-4 w-4 text-primary" />
-                        <span className="text-sm font-medium">Save for Re-sync</span>
+                        <div>
+                          <span className="text-sm font-medium">Save for Re-sync</span>
+                          <p className="text-xs text-muted-foreground">Find it later in IPTV Sources</p>
+                        </div>
                       </div>
                       <Switch checked={saveSource} onCheckedChange={setSaveSource} />
                     </div>


### PR DESCRIPTION
Follow-up to #697 (multipart parsing). With multipart fixed, importing a real IPTV/radio M3U still produced no usable channels — they imported but were invisible, mis-typed, and had no artwork. This PR makes the M3U/IPTV import flow work end to end.

Tested against the public **Tundrak/IPTV-Italia** playlists (`iptvita.m3u`, `iptvitaplus.m3u`, `ipradioita.m3u`): before, the main playlist imported **0** live channels; after, all 71 import as Live TV with logos where available.

### Backend — `import` (commit 1)
- **`media.id` is `INT4`.** `import_tv_channel` read it back as `i64`, so the sqlx decode failed, the id never resolved, and **every channel was silently skipped** (created an orphan media with no stream/catalog). Read/insert as `i32`. This is the root cause of "import says success but nothing shows up".
- **Catalog linking.** Imported channels are now linked to a catalog (`Live TV`, or `Radio` for audio streams), so they appear in Library Browse and the Stremio catalog instead of being orphaned.
- **Content-type detection priority.** A live-stream URL (HLS/DASH/TS) now wins over title parsing, and name-based *series* detection requires a **season** marker. Live channels whose names carry a number — `"[5] Canale 5"`, `"Rai 4"` — were being read as episode numbers and mis-classified as series (the entire main playlist). Audio streams classify as `tv` (Radio); extension-less live URLs (e.g. RAI relinker) default to a live channel instead of being skipped. Covered by unit tests.
- **Posters.** The importer wrote the `tvg-logo` to a non-existent `media.poster` column (the UPDATE errored silently); the `/poster` handler only reads `media_image`. Now the logo is persisted to `media_image` (`image_type='poster'`, under a dedicated `m3u` metadata provider).
- **Source naming.** Saved sources are named from the playlist filename (`M3U - iptvita`) so several playlists from one host stay distinguishable in IPTV Sources.

### Backend — `poster` (commit 2)
- IPTV channels and radios frequently ship no logo. Instead of a 404 (broken image), generate a 300×450 placeholder from the title with a stable hashed background colour, cached like any other poster.

### Frontend (commit 3)
- Always send `m3u_url` on import so the source can be saved for re-sync.
- Add a `Radio` entry to the Configure catalog list (Live & Sports).
- Under "Save for Re-sync", note that the playlist reappears in IPTV Sources.

### Testing
- `cargo test` (new `detection_tests`), `cargo clippy --all-targets` clean.
- Verified end to end on a live instance: 3 distinct sources, correct counts, real channel logos rendering in Library (RTL 102.5, M2O TV, RDS Social TV…) with placeholders for logo-less channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic auto-generated placeholder poster images (300×450 JPEG) for channels when no poster is available
  * Added a **Radio** catalog option for audio-only content
* **Improvements**
  * Enhanced M3U/IPTV import with precedence-based content-type detection, improved source persistence for re-sync, and better playlist/source naming
  * Improved poster serving to fall back to cached placeholders when upstream poster generation fails
  * Updated the “Save for Re-sync” UI copy and ensured the playlist URL is sent during import
* **Bug Fixes**
  * Fixed IPTV/M3U import media-id handling and logo persistence
* **Tests**
  * Added regression coverage for the updated import detection rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->