### PR TITLE
fix(torrin): start download and show placeholder for uncached playback

### DIFF
--- a/backend/src/providers/torrents/torrin.rs
+++ b/backend/src/providers/torrents/torrin.rs
@@ -6,13 +6,17 @@
 //! (`tr_...`) as store-level auth. All request/response handling, retries and
 //! file selection are reused from the StremThru implementation.
 
+use serde_json::json;
+
 use crate::providers::ProviderError;
+use crate::providers::response_json;
 use crate::providers::torrents::transport::MediaFlowForward;
 
 use super::DownloadedTorrent;
 use super::stremthru;
 
 const BASE_URL: &str = "https://api.torrin.app";
+const USER_AGENT: &str = "MediaFusion";
 
 /// Rewrite the bare Torrin key into a StremThru store token pinned to Torrin's
 /// API: `{url}|{store_name}:{store_token}`. The store name is arbitrary (Torrin
@@ -35,6 +39,40 @@ pub async fn list_downloaded_torrents(
     stremthru::list_downloaded_torrents(http, &stremthru_token(token)).await
 }
 
+/// Add the magnet to Torrin and return its store status. Content already in
+/// Torrin's R2 comes back `downloaded` instantly; anything else is now being
+/// pulled server-side. Uses Torrin's native bearer auth (which it accepts
+/// alongside the StremThru store headers).
+async fn add_and_status(
+    http: &reqwest::Client,
+    token: &str,
+    info_hash: &str,
+    announce_list: &[String],
+) -> Result<String, ProviderError> {
+    let trackers = announce_list
+        .iter()
+        .map(|t| format!("tr={}", urlencoding::encode(t)))
+        .collect::<Vec<_>>()
+        .join("&");
+    let magnet = format!("magnet:?xt=urn:btih:{info_hash}&{trackers}");
+
+    let resp = http
+        .post(format!("{BASE_URL}/v0/store/magnets"))
+        .header("User-Agent", USER_AGENT)
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&json!({ "magnet": magnet }))
+        .send()
+        .await?;
+
+    let body = response_json(resp, "torrin add magnet").await?;
+    Ok(body
+        .get("data")
+        .and_then(|d| d.get("status"))
+        .and_then(|s| s.as_str())
+        .unwrap_or_default()
+        .to_string())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn get_video_url(
     http: &reqwest::Client,
@@ -48,19 +86,35 @@ pub async fn get_video_url(
     user_ip: Option<&str>,
     forward: Option<&MediaFlowForward>,
 ) -> Result<String, ProviderError> {
-    stremthru::get_video_url(
-        http,
-        &stremthru_token(token),
-        info_hash,
-        announce_list,
-        filename,
-        file_index,
-        season,
-        episode,
-        user_ip,
-        forward,
-    )
-    .await
+    // Torrin has no shared instant cache (unlike RD/TB): a hash is either already
+    // in R2 (`downloaded`) or Torrin must pull the whole file (minutes), so
+    // blocking a playback request waiting for it is pointless. The add kicks off
+    // the download; resolve immediately when cached, otherwise hand back a
+    // "downloading" placeholder and let the user retry once Torrin finishes.
+    let status = add_and_status(http, token, info_hash, announce_list).await?;
+
+    if status.eq_ignore_ascii_case("downloaded") {
+        return stremthru::get_video_url(
+            http,
+            &stremthru_token(token),
+            info_hash,
+            announce_list,
+            filename,
+            file_index,
+            season,
+            episode,
+            user_ip,
+            forward,
+        )
+        .await;
+    }
+
+    Err(ProviderError::api(
+        format!(
+            "Torrin is downloading this title (status: {status}). Play again in a few minutes."
+        ),
+        "torrent_downloading.mp4",
+    ))
 }
 
 pub async fn delete_all_torrents(http: &reqwest::Client, token: &str) -> Result<(), ProviderError> {


### PR DESCRIPTION
The Torrin provider reused stremthru's get_video_url, which adds the magnet then polls up to 25s for `downloaded` and errors on timeout. Torrin has no shared instant cache like RD/TB: a hash is either already in R2 (`downloaded`) or Torrin pulls the whole file (minutes), so that always times out for genuinely uncached content and playback fails even though the download did start.

This overrides get_video_url in torrin.rs only (stremthru and other stores untouched): add the magnet, resolve immediately when `downloaded`, otherwise return the existing `torrent_downloading.mp4` placeholder so the user retries once Torrin finishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved torrent playback flow by checking download status before trying to generate a video link.
  * Added support for magnet-based requests with tracker information for better torrent handling.

* **Bug Fixes**
  * Prevents premature playback attempts while a torrent is still downloading.
  * Returns a clearer “downloading” response with a placeholder filename when content is not ready yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->