### PR TITLE
fix: improve Ukrainian language detection in PTT

### DIFF
--- a/backend/src/ptt/handlers.rs
+++ b/backend/src/ptt/handlers.rs
@@ -2187,7 +2187,7 @@ pub fn add_defaults(p: &mut Parser) {
     );
     p.add(
         "languages",
-        rei(r"\bUKR\b"),
+        rei(r"UKR\b"),
         uniq_concat(value("uk")),
         lo(false, false),
     );
@@ -2545,12 +2545,6 @@ pub fn add_defaults(p: &mut Parser) {
         uniq_concat(value("ja")),
         lo(false, true),
     ); // Halfwidth Katakana
-    p.add(
-        "languages",
-        re(r"[\x{0400}-\x{04ff}]+"),
-        uniq_concat(value("ru")),
-        lo(false, true),
-    ); // Cyrillic
     p.add(
         "languages",
         re(r"[\x{0600}-\x{06ff}]+"),

--- a/backend/src/ptt/mod.rs
+++ b/backend/src/ptt/mod.rs
@@ -431,4 +431,12 @@ mod tests {
         assert!(r.languages.contains(&"French".to_string()));
         assert!(r.languages.contains(&"Spanish".to_string()));
     }
+
+    #[test]
+    fn test_ukrainian_ukr_tag() {
+        let r = parse("Example.2021.1080p.BluRay.2xUkr.Eng.mkv", true);
+        assert_eq!(r.languages.len(), 2);
+        assert!(r.languages.contains(&"Ukrainian".to_string()));
+        assert!(r.languages.contains(&"English".to_string()));
+    }
 }


### PR DESCRIPTION
Fixes #712

Drop left word boundary on `UKR` regex so `2xUkr/Eng` is detected as Ukrainian instead of Russian. Remove Cyrillic script catch-all that unconditionally mapped any Cyrillic text to Russian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Ukrainian language tags in filenames.
  * Updated language inference to avoid incorrectly identifying certain Cyrillic text as Russian.
* **Tests**
  * Added coverage confirming Ukrainian and English language tags are translated and detected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->