### PR TITLE
fix: enable cookie store for reqwest client

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1230,10 +1230,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -4305,6 +4334,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +4742,8 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
  "futures-util",
  "h2",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -71,7 +71,7 @@ serde_json = "1"
 quick-xml = { version = "0.41", features = ["serde"] }
 
 # HTTP client (live scrapers)
-reqwest = { version = "0.13", default-features = false, features = ["gzip", "brotli", "http2", "json", "multipart", "form", "query", "stream"] }
+reqwest = { version = "0.13", default-features = false, features = ["gzip", "brotli", "http2", "json", "multipart", "form", "query", "stream", "cookies"] }
 openssl = { version = "0.10", optional = true }
 
 # Database

--- a/backend/src/util/http.rs
+++ b/backend/src/util/http.rs
@@ -63,6 +63,7 @@ pub fn build(proxy_url: Option<&str>, keepalive_secs: u64) -> reqwest::Client {
     let mut builder = reqwest::Client::builder()
         .user_agent("MediaFusion/1.0 (+https://github.com/mhdzumair/MediaFusion)")
         .http1_only()
+        .cookie_store(true)
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
         .pool_idle_timeout(Duration::from_secs(20))


### PR DESCRIPTION
## Problem

The shared HTTP client in `backend/src/util/http.rs` creates a `reqwest::Client` without `.cookie_store(true)`. reqwests default is `false`, so `Set-Cookie` headers from any endpoint are silently discarded.

The qBittorrent provider is the primary victim: `qb_login()` POSTs to `/api/v2/auth/login`, qBittorrent responds with `Set-Cookie: SID=...`, but the cookie is never stored. Every subsequent API call (`torrents/info`, `torrents/add`, `app/setPreferences`) is unauthenticated and returns empty results.

## Fix

One line: `.cookie_store(true)` on the client builder in `build()`. Safe for all callers — endpoints that do not use cookies are unaffected.

## Regression

The Python predecessor used `requests.Session` which preserves cookies by default. This was lost during the Rust migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound web requests by enabling cookie handling to support more reliable sessions and authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->