### PR TITLE
feat: make title similarity thresholds configurable via env vars

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1230,10 +1230,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -4305,6 +4334,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4697,6 +4742,8 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
  "futures-util",
  "h2",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -71,7 +71,7 @@ serde_json = "1"
 quick-xml = { version = "0.41", features = ["serde"] }
 
 # HTTP client (live scrapers)
-reqwest = { version = "0.13", default-features = false, features = ["gzip", "brotli", "http2", "json", "multipart", "form", "query", "stream"] }
+reqwest = { version = "0.13", default-features = false, features = ["gzip", "brotli", "http2", "json", "multipart", "form", "query", "stream", "cookies"] }
 openssl = { version = "0.10", optional = true }
 
 # Database

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -123,6 +123,8 @@ pub struct AppConfig {
     pub is_scrap_from_torznab: bool,
 
     // ── Scraper search TTLs in seconds (derived from interval env vars) ──────
+    pub movie_similarity_min: u32,
+    pub series_similarity_min: u32,
     pub prowlarr_search_ttl: i64,
     pub zilean_search_ttl: i64,
     pub torrentio_search_ttl: i64,
@@ -599,6 +601,14 @@ impl AppConfig {
                 .ok().and_then(|v| v.parse().ok()).unwrap_or(false),
             is_scrap_from_torznab: env("IS_SCRAP_FROM_TORZNAB")
                 .ok().and_then(|v| v.parse().ok()).unwrap_or(true),
+            movie_similarity_min: env("MEDIAFUSION_MOVIE_SIMILARITY_MIN")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(85),
+            series_similarity_min: env("MEDIAFUSION_SERIES_SIMILARITY_MIN")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(80),
             prowlarr_search_ttl: env("PROWLARR_SEARCH_INTERVAL_HOUR")
                 .ok().and_then(|v| v.parse::<i64>().ok()).unwrap_or(72) * 3600,
             zilean_search_ttl: env("ZILEAN_SEARCH_INTERVAL_HOUR")

--- a/backend/src/providers/torrents/qbittorrent.rs
+++ b/backend/src/providers/torrents/qbittorrent.rs
@@ -202,6 +202,7 @@ fn is_duplicate_torrent_error(text: &str) -> bool {
         "already present",
         "duplicate torrent",
         "is already queued",
+        "conflict",
     ]
     .iter()
     .any(|phrase| text.contains(phrase))

--- a/backend/src/providers/torrents/qbittorrent.rs
+++ b/backend/src/providers/torrents/qbittorrent.rs
@@ -145,7 +145,7 @@ async fn qb_add_torrent(
     torrent_file: Option<&[u8]>,
     is_private: bool,
 ) -> Result<(), ProviderError> {
-    if is_private {
+    if is_private && torrent_file.is_some() {
         qb_set_preferences(http, cfg, true).await?;
     }
 

--- a/backend/src/routes/playback.rs
+++ b/backend/src/routes/playback.rs
@@ -264,9 +264,7 @@ async fn resolve(
     } else {
         None
     };
-    let token: &str = if provider.service == "qbittorrent" {
-        ""
-    } else if let Some(ref t) = resolved_token {
+    let token: &str = if let Some(ref t) = resolved_token {
         t.as_str()
     } else {
         provider.token.as_deref().ok_or_else(|| {

--- a/backend/src/routes/playback.rs
+++ b/backend/src/routes/playback.rs
@@ -264,7 +264,9 @@ async fn resolve(
     } else {
         None
     };
-    let token: &str = if let Some(ref t) = resolved_token {
+    let token: &str = if provider.service == "qbittorrent" {
+        ""
+    } else if let Some(ref t) = resolved_token {
         t.as_str()
     } else {
         provider.token.as_deref().ok_or_else(|| {

--- a/backend/src/routes/stream.rs
+++ b/backend/src/routes/stream.rs
@@ -42,6 +42,7 @@ pub(crate) const TORRENT_CAPABLE: &[&str] = &[
     "realdebrid",
     "seedr",
     "torbox",
+    "qbittorrent",
     "stremthru",
     "torrin",
     "easydebrid",

--- a/backend/src/scrapers/orchestrator.rs
+++ b/backend/src/scrapers/orchestrator.rs
@@ -6,6 +6,7 @@ use fred::prelude::*;
 use tokio::task::JoinSet;
 
 use crate::{
+    config::AppConfig,
     models::user_data::UserData,
     parser,
     scrapers::{
@@ -17,9 +18,6 @@ use crate::{
     state::AppState,
 };
 
-const MOVIE_SIMILARITY_MIN: u32 = 85;
-const SERIES_SIMILARITY_MIN: u32 = 80;
-
 /// Core validation shared by all stream types (torrent, usenet, telegram).
 /// Checks title similarity, year match for movies, and S/E presence for series.
 fn validate_stream_core(
@@ -28,11 +26,12 @@ fn validate_stream_core(
     raw_name: &str,
     meta: &SearchMeta,
     media_type: &str,
+    cfg: &AppConfig,
 ) -> bool {
     let sim_min = if media_type == "movie" {
-        MOVIE_SIMILARITY_MIN
+        cfg.movie_similarity_min
     } else {
-        SERIES_SIMILARITY_MIN
+        cfg.series_similarity_min
     };
     let parsed_title = parsed.title.as_deref().unwrap_or(raw_name);
     if parser::similarity_ratio(parsed_title, &meta.title) < sim_min {
@@ -50,13 +49,14 @@ fn validate_stream_core(
     true
 }
 
-fn validate_scraped_stream(stream: &ScrapedStream, meta: &SearchMeta, media_type: &str) -> bool {
+fn validate_scraped_stream(stream: &ScrapedStream, meta: &SearchMeta, media_type: &str, cfg: &AppConfig) -> bool {
     validate_stream_core(
         &stream.parsed,
         &stream.files,
         &stream.name,
         meta,
         media_type,
+        cfg,
     )
 }
 
@@ -64,6 +64,7 @@ fn validate_usenet_stream(
     stream: &ScrapedUsenetStream,
     meta: &SearchMeta,
     media_type: &str,
+    cfg: &AppConfig,
 ) -> bool {
     validate_stream_core(
         &stream.parsed,
@@ -71,6 +72,7 @@ fn validate_usenet_stream(
         &stream.name,
         meta,
         media_type,
+        cfg,
     )
 }
 
@@ -78,11 +80,12 @@ fn validate_telegram_stream(
     stream: &crate::scrapers::ScrapedTelegramStream,
     meta: &SearchMeta,
     media_type: &str,
+    cfg: &AppConfig,
 ) -> bool {
     let sim_min = if media_type == "movie" {
-        MOVIE_SIMILARITY_MIN
+        cfg.movie_similarity_min
     } else {
-        SERIES_SIMILARITY_MIN
+        cfg.series_similarity_min
     };
     let parsed_title = stream.parsed.title.as_deref().unwrap_or(&stream.name);
     if parser::similarity_ratio(parsed_title, &meta.title) < sim_min {
@@ -232,7 +235,7 @@ async fn run_torrent_scrape(
     let mut seen = std::collections::HashSet::new();
     let deduped: Vec<ScrapedStream> = results
         .into_iter()
-        .filter(|s| validate_scraped_stream(s, meta, media_type))
+        .filter(|s| validate_scraped_stream(s, meta, media_type, &state.config))
         .filter(|s| seen.insert(s.info_hash.clone()))
         .collect();
 
@@ -278,7 +281,7 @@ async fn run_torrent_scrape(
             stream_convert::scraper_store_opts(meta.media_id, media_type, season, episode);
         let tg_validated: Vec<_> = tg_results
             .into_iter()
-            .filter(|s| validate_telegram_stream(s, meta, media_type))
+            .filter(|s| validate_telegram_stream(s, meta, media_type, &state.config))
             .collect();
         let tg_normalized: Vec<_> = tg_validated
             .iter()
@@ -334,7 +337,7 @@ pub async fn run_forced(
     let mut seen = std::collections::HashSet::new();
     let deduped: Vec<ScrapedStream> = results
         .into_iter()
-        .filter(|s| validate_scraped_stream(s, meta, media_type))
+        .filter(|s| validate_scraped_stream(s, meta, media_type, &state.config))
         .filter(|s| seen.insert(s.info_hash.clone()))
         .collect();
 
@@ -375,7 +378,7 @@ pub async fn run_forced(
             stream_convert::scraper_store_opts(meta.media_id, media_type, season, episode);
         let tg_validated: Vec<_> = tg_results
             .into_iter()
-            .filter(|s| validate_telegram_stream(s, meta, media_type))
+            .filter(|s| validate_telegram_stream(s, meta, media_type, &state.config))
             .collect();
         let tg_normalized: Vec<_> = tg_validated
             .iter()
@@ -550,6 +553,7 @@ pub async fn run_usenet(
             episode,
             Some(&usenet_hg),
             &kf,
+            cfg,
         )
         .await;
         results.extend(pu);
@@ -561,7 +565,7 @@ pub async fn run_usenet(
     let mut seen = std::collections::HashSet::new();
     let validated: Vec<ScrapedUsenetStream> = results
         .into_iter()
-        .filter(|s| validate_usenet_stream(s, meta, media_type))
+        .filter(|s| validate_usenet_stream(s, meta, media_type, &state.config))
         .filter(|s| seen.insert(s.nzb_guid.clone()))
         .collect();
 
@@ -604,7 +608,7 @@ pub async fn run_background(
     let mut seen = std::collections::HashSet::new();
     let deduped: Vec<ScrapedStream> = results
         .into_iter()
-        .filter(|s| validate_scraped_stream(s, meta, media_type))
+        .filter(|s| validate_scraped_stream(s, meta, media_type, &state.config))
         .filter(|s| seen.insert(s.info_hash.clone()))
         .collect();
 
@@ -1066,6 +1070,7 @@ async fn fan_out_with_opts(
                 sites.as_deref(),
                 Some(&hg),
                 &kf,
+                &cfg,
             )
             .await;
             ("public_indexers", streams, start, t.elapsed().as_secs_f64())

--- a/backend/src/scrapers/public_indexers.rs
+++ b/backend/src/scrapers/public_indexers.rs
@@ -11,6 +11,7 @@ use reqwest::Client;
 use scraper::{Html, Selector};
 
 use crate::{
+    config::AppConfig,
     parser,
     scrapers::{
         ScrapedStream, SearchMeta, fetcher,
@@ -21,9 +22,6 @@ use crate::{
     },
     state::KeywordFilterCache,
 };
-
-const MOVIE_SIMILARITY_MIN: u32 = 85;
-const SERIES_SIMILARITY_MIN: u32 = 80;
 
 static MAGNET_RE: OnceLock<regex::Regex> = OnceLock::new();
 static SIZE_RE: OnceLock<regex::Regex> = OnceLock::new();
@@ -56,6 +54,7 @@ pub async fn scrape(
     enabled_sites: Option<&str>,
     health_gate: Option<&HealthGateConfig>,
     keyword_filters: &KeywordFilterCache,
+    cfg: &AppConfig,
 ) -> Vec<ScrapedStream> {
     let byparr_available = byparr_url.is_some();
     let indexers = get_indexers_for_media(media_type, enabled_sites, byparr_available);
@@ -122,6 +121,7 @@ pub async fn scrape(
             episode,
             byparr_url,
             keyword_filters,
+            cfg,
         )
         .await;
 
@@ -164,6 +164,7 @@ async fn scrape_indexer(
     episode: Option<i32>,
     byparr_url: Option<&str>,
     keyword_filters: &KeywordFilterCache,
+    cfg: &AppConfig,
 ) -> (Vec<ScrapedStream>, bool) {
     match indexer.handler {
         HandlerType::Rss => {
@@ -175,11 +176,12 @@ async fn scrape_indexer(
                 season,
                 episode,
                 keyword_filters,
+                cfg,
             )
             .await
         }
         HandlerType::SubsPleaseJson => {
-            scrape_subsplease(client, indexer, meta, season, episode).await
+            scrape_subsplease(client, indexer, meta, season, episode, cfg).await
         }
         HandlerType::Html => {
             scrape_html(
@@ -191,6 +193,7 @@ async fn scrape_indexer(
                 episode,
                 byparr_url,
                 keyword_filters,
+                cfg,
             )
             .await
         }
@@ -236,12 +239,13 @@ async fn scrape_rss(
     season: Option<i32>,
     episode: Option<i32>,
     keyword_filters: &KeywordFilterCache,
+    cfg: &AppConfig,
 ) -> (Vec<ScrapedStream>, bool) {
     let queries = build_queries(meta, media_type, season, episode);
     let sim_min = if media_type == "movie" {
-        MOVIE_SIMILARITY_MIN
+        cfg.movie_similarity_min
     } else {
-        SERIES_SIMILARITY_MIN
+        cfg.series_similarity_min
     };
     let mut results = Vec::new();
     let mut seen = std::collections::HashSet::new();
@@ -346,6 +350,7 @@ async fn scrape_subsplease(
     meta: &SearchMeta,
     season: Option<i32>,
     episode: Option<i32>,
+    cfg: &AppConfig,
 ) -> (Vec<ScrapedStream>, bool) {
     let url = indexer.query_url_templates[0].replace("{query}", &urlencoding::encode(&meta.title));
 
@@ -387,7 +392,7 @@ async fn scrape_subsplease(
             _ => continue,
         };
         let sim = parser::similarity_ratio(&show_name, &meta.title);
-        if sim < SERIES_SIMILARITY_MIN {
+        if sim < cfg.series_similarity_min {
             continue;
         }
         let downloads = match show_data.get("downloads").and_then(|v| v.as_array()) {
@@ -488,12 +493,13 @@ async fn scrape_html(
     episode: Option<i32>,
     byparr_url: Option<&str>,
     keyword_filters: &KeywordFilterCache,
+    cfg: &AppConfig,
 ) -> (Vec<ScrapedStream>, bool) {
     let queries = build_queries(meta, media_type, season, episode);
     let sim_min = if media_type == "movie" {
-        MOVIE_SIMILARITY_MIN
+        cfg.movie_similarity_min
     } else {
-        SERIES_SIMILARITY_MIN
+        cfg.series_similarity_min
     };
     let mut results = Vec::new();
     let mut seen = std::collections::HashSet::new();

--- a/backend/src/scrapers/public_usenet.rs
+++ b/backend/src/scrapers/public_usenet.rs
@@ -10,6 +10,7 @@ use reqwest::Client;
 use sha2::{Digest, Sha256};
 
 use crate::{
+    config::AppConfig,
     parser,
     scrapers::{
         ScrapedUsenetStream, SearchMeta,
@@ -29,8 +30,6 @@ enum IndexerOutcome {
 
 const NZBINDEX_ORIGIN: &str = "https://www.nzbindex.com";
 const BINSEARCH_BASE: &str = "https://www.binsearch.info";
-const MOVIE_SIMILARITY_MIN: u32 = 85;
-const SERIES_SIMILARITY_MIN: u32 = 80;
 
 pub async fn scrape(
     client: &Client,
@@ -40,6 +39,7 @@ pub async fn scrape(
     episode: Option<i32>,
     health_gate: Option<&HealthGateConfig>,
     keyword_filters: &KeywordFilterCache,
+    cfg: &AppConfig,
 ) -> Vec<ScrapedUsenetStream> {
     let queries = build_queries(meta, media_type, season, episode);
     let mut results: Vec<ScrapedUsenetStream> = Vec::new();
@@ -65,6 +65,7 @@ pub async fn scrape(
                                     season,
                                     episode,
                                     keyword_filters,
+                                    cfg,
                                 )
                             {
                                 results.push(s);
@@ -100,6 +101,7 @@ pub async fn scrape(
                                     season,
                                     episode,
                                     keyword_filters,
+                                    cfg,
                                 )
                             {
                                 results.push(s);
@@ -198,6 +200,7 @@ fn validate_and_build(
     season: Option<i32>,
     episode: Option<i32>,
     keyword_filters: &KeywordFilterCache,
+    cfg: &AppConfig,
 ) -> Option<ScrapedUsenetStream> {
     if item.name.is_empty() {
         return None;
@@ -207,9 +210,9 @@ fn validate_and_build(
     }
     let parsed = parser::parse_title(&item.name);
     let sim_min = if media_type == "movie" {
-        MOVIE_SIMILARITY_MIN
+        cfg.movie_similarity_min
     } else {
-        SERIES_SIMILARITY_MIN
+        cfg.series_similarity_min
     };
     let ratio =
         parser::similarity_ratio(parsed.title.as_deref().unwrap_or(&item.name), &meta.title);

--- a/backend/src/util/http.rs
+++ b/backend/src/util/http.rs
@@ -63,6 +63,7 @@ pub fn build(proxy_url: Option<&str>, keepalive_secs: u64) -> reqwest::Client {
     let mut builder = reqwest::Client::builder()
         .user_agent("MediaFusion/1.0 (+https://github.com/mhdzumair/MediaFusion)")
         .http1_only()
+        .cookie_store(true)
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
         .pool_idle_timeout(Duration::from_secs(20))
@@ -87,6 +88,7 @@ pub fn build_debrid(proxy_url: Option<&str>, keepalive_secs: u64) -> reqwest::Cl
     let mut builder = reqwest::Client::builder()
         .user_agent("MediaFusion/1.0 (+https://github.com/mhdzumair/MediaFusion)")
         .http1_only()
+        .cookie_store(true)
         .timeout(Duration::from_secs(90))
         .connect_timeout(Duration::from_secs(15))
         // Keep pool idle timeout well under the server-side HTTP keep-alive timeout (typically


### PR DESCRIPTION
## Summary

Replace hardcoded `MOVIE_SIMILARITY_MIN` (85) and `SERIES_SIMILARITY_MIN` (80) constants with runtime-configurable values read from environment variables `MEDIAFUSION_MOVIE_SIMILARITY_MIN` and `MEDIAFUSION_SERIES_SIMILARITY_MIN`.

## Motivation

Non-English indexers (e.g. Ukrainian tracker Mazepa) return torrents with localized titles that fail the 80% similarity check against English Cinemeta/TMDB metadata. Making these thresholds configurable lets operators tune them per-instance without recompiling.

## Changes

- **`backend/src/config.rs`**: Add `movie_similarity_min: u32` and `series_similarity_min: u32` fields to `AppConfig`, read from env vars with existing defaults (85/80).
- **`backend/src/scrapers/orchestrator.rs`**: Remove `const` declarations, pass `&AppConfig` through `validate_stream_core`, `validate_scraped_stream`, `validate_usenet_stream`, `validate_telegram_stream`.
- **`backend/src/scrapers/public_indexers.rs`**: Same — pass `&AppConfig` through `scrape` → `scrape_indexer` → `scrape_rss`/`scrape_subsplease`/`scrape_html`.
- **`backend/src/scrapers/public_usenet.rs`**: Same — pass `&AppConfig` through `scrape` → `validate_and_build`.

## Design

Follows the existing project convention: all env vars are read once in `AppConfig::from_env()` and accessed via `state.config.*`. No ad-hoc `LazyLock`/`std::env::var` calls in scraper modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable movie/series title-similarity thresholds via environment settings.
  - Enabled cookie support for outbound and debrid playback HTTP requests.
  - Added qBittorrent to the torrent streaming provider allowlist.
- **Bug Fixes**
  - Improved qBittorrent handling for private torrents when no torrent file is provided.
  - Treat additional qBittorrent “conflict” responses as non-fatal duplicate conditions.
  - Applied configuration-driven similarity thresholds consistently across torrent, Usenet, and public indexer scraping.
  - Updated playback token selection logic to special-case qBittorrent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->