### PR TITLE
Update TamilMV homepage URL

### DIFF
--- a/backend/src/jobs/handlers/spiders/tamil_forums.rs
+++ b/backend/src/jobs/handlers/spiders/tamil_forums.rs
@@ -598,7 +598,7 @@ impl JobHandler for TamilMvCrawl {
     async fn run(&self, args: Self::Args, ctx: JobCtx) -> Result<(), JobError> {
         let (pages, start_page) = parse_listing_page_args(&args);
         let root = crate::scrapers::scraper_config::load(&ctx.state).await;
-        let homepage = spider_homepage("tamilmv", "https://www.1tamilmv.earth", &root);
+        let homepage = spider_homepage("tamilmv", "https://www.1tamilmv.observer", &root);
         let catalogs = load_catalogs("tamilmv", &root);
         scrape_tamil_forum(
             "tamilmv", "TamilMV", &homepage, &catalogs, pages, start_page, &ctx,

--- a/resources/json/scraper_config.json
+++ b/resources/json/scraper_config.json
@@ -80,7 +80,7 @@
 	}
   },
   "tamilmv": {
-	"homepage": "https://www.1tamilmv.earth",
+	"homepage": "https://www.1tamilmv.observer",
 	"catalogs": {
 	  "tamil": {
 		"hdrip": [


### PR DESCRIPTION
## Summary
- replace the defunct TamilMV `.earth` homepage with the active `.observer` domain

## Verification
- parsed `resources/json/scraper_config.json` successfully
- confirmed `https://www.1tamilmv.observer/` responds successfully and serves the TamilMV site
- confirmed the previous `.earth` domain no longer resolves from a deployed MediaFusion instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the TamilMV homepage URL to the current address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->