### PR TITLE
Validate api_password in /encrypt-user-data on private instances

### DIFF
--- a/backend/src/routes/encrypt.rs
+++ b/backend/src/routes/encrypt.rs
@@ -29,6 +29,26 @@ pub async fn handler(
         }
     };
 
+    // On private instances the api_password embedded in the config is what the
+    // stremio_auth_middleware later checks on every /{secret_str}/... request.
+    // Reject a wrong or missing password here instead of minting a secret that
+    // can only ever produce 401s at install time.
+    if !state.config.is_public_instance
+        && let Some(ref required) = state.config.api_password
+    {
+        let provided = user_data.api_password.as_deref().unwrap_or("");
+        if provided != required.as_str() {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({
+                    "status": "error",
+                    "message": "Invalid or missing API password. Enter this instance's API password and try again.",
+                })),
+            )
+                .into_response();
+        }
+    }
+
     let default_nzbdav = state
         .config
         .default_nzbdav_url


### PR DESCRIPTION
## Problem

On a private instance (`API_PASSWORD` set, `is_public_instance = false`), `POST /encrypt-user-data` accepts any — or no — `api_password` and mints a `D-` secret anyway. The embedded password is only checked later by `stremio_auth_middleware`, so the user gets a manifest URL that can never install: every `/{secret_str}/manifest.json` fetch returns 401, with no hint at configure time about what's wrong.

This bites hardest after an instance password rotation: the frontend prefers the api key stored in `localStorage` (`mediafusion_api_key`) over the value typed in the form, so users regenerate URL after URL that all embed the stale password and all 401 on install. (Diagnosed this from a real support case on ElfHosted — the user rotated their instance password four times trying to fix it, since nothing in the UI ever reported an error.)

## Change

Validate the embedded `api_password` in the `/encrypt-user-data` handler, mirroring the exact check `stremio_auth_middleware` applies later, and return `401` with `{"status": "error", "message": ...}` on mismatch. The frontend's `encryptUserData()` already surfaces `message` from non-OK responses, so users now see a clear "Invalid or missing API password" error at generation time instead of a broken install URL.

- Public instances and instances with no `API_PASSWORD` configured are unaffected.
- The check runs before provider credential validation, so unauthenticated callers can no longer exercise upstream provider-validation calls either.
- Only `D-` secrets are minted by this endpoint, so the `U-` (logged-in profile) exemption in the middleware is untouched.

## Testing

- `cargo check`, `cargo clippy` (no warnings), `cargo fmt --check` all clean.
- Manually verified against a live 6.1.3 private instance: wrong/missing password previously returned `200` + a secret whose manifest 401s; correct password still mints a working secret.

## Possible follow-up (not in this PR)

The frontend could clear the stored `mediafusion_api_key` when this 401 comes back, so a stale key from before a password rotation doesn't silently override the typed value forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added password validation for private instances before encryption.
  * Missing or incorrect passwords now return a clear authorization error.
  * Public instances and private instances without configured passwords continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->