### PR TITLE
deps: bump protego to 0.6.2 (GHSA-wjmf-p669-5m5p)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2606,11 +2606,11 @@ wheels = [
 
 [[package]]
 name = "protego"
-version = "0.6.0"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/a7/955c422611d00a6e4a06d30b367ea9bb4fb09d48552e92aef1ba312493c7/protego-0.6.0.tar.gz", hash = "sha256:3466f41438421cf90008e98534d5fde47dc16a17482571d021143ac18b70ace9", size = 3137423, upload-time = "2026-01-29T10:58:28.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1b/6b0ee60bb1561843bfc62f5c7c3cb1ef6147b47e829a5fd6b7fcd2752471/protego-0.6.2.tar.gz", hash = "sha256:88ff004544ce44e61269cc6f8735f7837d12e09bb77619fc94fbb26b72e5d137", size = 3137854, upload-time = "2026-06-25T09:33:16.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/8c/f4dd590f48addf31398f78a78962eaa99eb4c87ac09c1927497032644731/protego-0.6.0-py3-none-any.whl", hash = "sha256:7210e6e06a8db839502baf1bfbcb810689a58e394d31408ef1ef9e4e3d79fc44", size = 10313, upload-time = "2026-01-29T10:58:26.748Z" },
+    { url = "https://files.pythonhosted.org/packages/61/10/cbd3c06603bb8b3e0e871df24ee793a6e3b53d8c4cc8763f1b8b936649aa/protego-0.6.2-py3-none-any.whl", hash = "sha256:714de21d82527c9be900066c3211b266985dd6a19b6e70c57e033fc1a589f3ff", size = 10296, upload-time = "2026-06-25T09:33:14.688Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates `protego` to address GHSA-wjmf-p669-5m5p (CVE-2026-55520, ReDoS in robots.txt wildcard matching).

Evidence:
- `uv.lock` pinned `protego 0.6.0` (transitive via `scrapy` and `scrapling`)
- osv-scanner reported GHSA-wjmf-p669-5m5p for protego 0.6.0 before the update
- updated version: `0.6.2`

Validation:
- osv-scanner no longer reports GHSA-wjmf-p669-5m5p after the update
- `uv lock --check` passes with the surgical lock entry update
- `uv sync --all-extras` resolves and installs cleanly
- documented `uv run pytest` collects no runnable tests in this checkout as-is: the `tests/` testpath resolves into `python-deprecated/tests/` which fails collection without the reference symlink and service env vars, both before and after this change

Scope: dependency/lockfile update only.
